### PR TITLE
Use dist mode by default when used as ZF2 module

### DIFF
--- a/view/zf-apigility-ui.phtml
+++ b/view/zf-apigility-ui.phtml
@@ -1,5 +1,5 @@
 <?php
-$version = 'src';
+$version = 'dist';
 $path    = __DIR__ . '/../' . $version . '/zf-apigility-admin/index.html';
 $apiBase = $this->url('zf-apigility/api/module');
 $apiBase = substr($apiBase, 0, strrpos($apiBase, '/'));


### PR DESCRIPTION
- Inadvertently committed a change that switched from dist to src mode by
  default; reverted to allow using out-of-the-box.
