### PR TITLE
Implement "type to select" for dropdowns

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -36,7 +36,9 @@
     "angular-ladda": "~0.1.10",
     "angular-unsavedChanges": "~0.1.1",
     "checklist-model": "~0.1.3",
-    "angular-bootstrap-toggle-switch": "~0.5.2"
+    "angular-bootstrap-toggle-switch": "~0.5.2",
+    "angular-ui-select": "~0.11.2",
+    "angular-sanitize": "1.2.28"
   },
   "devDependencies": {
     "angular-mocks": "~1.2.26"

--- a/src/apigility-ui/app.config.js
+++ b/src/apigility-ui/app.config.js
@@ -13,7 +13,7 @@
             $element[0].focus();
           });
         }
-      }
+      };
     }]);
 
   config.$inject = [
@@ -21,10 +21,11 @@
     '$stateProvider',
     '$urlRouterProvider',
     '$httpProvider',
-    'localStorageServiceProvider'
+    'localStorageServiceProvider',
+    'uiSelectConfig'
   ];
 
-  function config ($provide, $stateProvider, $urlRouterProvider, $httpProvider, localStorageServiceProvider) {
+  function config ($provide, $stateProvider, $urlRouterProvider, $httpProvider, localStorageServiceProvider, uiSelectConfig) {
 
     $provide.value(
       'agApiPath',
@@ -33,6 +34,7 @@
       '/api'
     );
 
+    /* jshint validthis: true */
     $stateProvider.state({
       name : 'ag',
       url : '/',
@@ -42,19 +44,19 @@
           templateUrl: 'apigility-ui/header/header.html',
           controller: 'Header',
           controllerAs: 'vm',
-          parent : this
+          parent: this
         },
         'sidebar@': {
           templateUrl: 'apigility-ui/sidebar/sidebar.html',
           controller: 'Sidebar',
           controllerAs: 'vm',
-          parent : this
+          parent: this
         },
         'content@': {
           templateUrl: 'apigility-ui/dashboard/dashboard.html',
           controller: 'Dashboard',
           controllerAs: 'vm',
-          parent : this
+          parent: this
         }
       }
     });
@@ -64,6 +66,7 @@
     localStorageServiceProvider
       .setPrefix('apigility');
 
+    uiSelectConfig.theme = 'bootstrap';
   }
 
 })();

--- a/src/apigility-ui/app.module.js
+++ b/src/apigility-ui/app.module.js
@@ -16,9 +16,11 @@
       'apigility.package',
       'apigility.about',
 
+      'ngSanitize',
       'ui.bootstrap',
       'ui.router',
       'ui.tree',
+      'ui.select',
       'angular-ladda',
       'unsavedChanges',
       'ngTagsInput',

--- a/src/apigility-ui/modal/add-filter.controller.js
+++ b/src/apigility-ui/modal/add-filter.controller.js
@@ -28,21 +28,22 @@
 
     api.getFilters(function(result){
       vm.filters = result;
+      vm.filterNames = [];
       // Remove the validators already present in the field
       for (var property in result) {
         if (fieldFilters.indexOf(property) > -1) {
           delete vm.filters[property];
           continue;
         }
-        vm.filterNames.push({ name: property });
+        vm.filterNames.push(property);
       }
     });
 
     vm.selectFilter = function(item, model) {
-      vm.options = vm.filters[item.name];
+      vm.options = vm.filters[item];
       vm.optionNames = [];
       for (var property in vm.options) {
-        vm.optionNames.push({ name: property });
+        vm.optionNames.push(property);
       }
     };
 
@@ -51,9 +52,8 @@
     };
 
     vm.addOption = function() {
-      /* since option.name is a model, it's nested; pull nested name */
-      if (!vm.filter.options.hasOwnProperty(vm.option.name.name)) {
-        vm.filter.options[vm.option.name.name] = vm.option.value;
+      if (!vm.filter.options.hasOwnProperty(vm.option.name)) {
+        vm.filter.options[vm.option.name] = vm.option.value;
       }
     };
 
@@ -64,8 +64,6 @@
     };
 
     function addFilter(fields, field, filter){
-      /* since filter.name is a model, it's nested; pull nested name */
-      filter.name = filter.name.name;
       for(var i = 0; i < fields.length; i++) {
         if (fields[i].name == field.name) {
           fields[i].filters.push(filter);

--- a/src/apigility-ui/modal/add-filter.controller.js
+++ b/src/apigility-ui/modal/add-filter.controller.js
@@ -17,6 +17,9 @@
 
     vm.cancel = $modalInstance.dismiss;
     vm.filter = { name : '', options : {} };
+    vm.filters = {};
+    vm.filterNames = [];
+    vm.optionNames = [];
 
     var fieldFilters = [];
     field.filters.forEach(function(entry){
@@ -29,27 +32,40 @@
       for (var property in result) {
         if (fieldFilters.indexOf(property) > -1) {
           delete vm.filters[property];
+          continue;
         }
+        vm.filterNames.push({ name: property });
       }
     });
 
-    vm.selectFilter = function() {
-      vm.options = vm.filters[vm.filter.name];
-    }
+    vm.selectFilter = function(item, model) {
+      vm.options = vm.filters[item.name];
+      vm.optionNames = [];
+      for (var property in vm.options) {
+        vm.optionNames.push({ name: property });
+      }
+    };
+
+    vm.selectOption = function(item, model) {
+      vm.option.value = '';
+    };
 
     vm.addOption = function() {
-      if (!vm.filter.options.hasOwnProperty(vm.option.name)) {
-        vm.filter.options[vm.option.name] = vm.option.value;
+      /* since option.name is a model, it's nested; pull nested name */
+      if (!vm.filter.options.hasOwnProperty(vm.option.name.name)) {
+        vm.filter.options[vm.option.name.name] = vm.option.value;
       }
-    }
+    };
 
     vm.deleteOption = function(option) {
       if (vm.filter.options.hasOwnProperty(option)) {
         delete vm.filter.options[option];
       }
-    }
+    };
 
     function addFilter(fields, field, filter){
+      /* since filter.name is a model, it's nested; pull nested name */
+      filter.name = filter.name.name;
       for(var i = 0; i < fields.length; i++) {
         if (fields[i].name == field.name) {
           fields[i].filters.push(filter);
@@ -59,7 +75,6 @@
     }
 
     vm.ok = function() {
-      vm.loading = true;
       var newFields = angular.copy(fields);
       addFilter(newFields, field, vm.filter);
       if (type === 'rest') {
@@ -81,7 +96,6 @@
           $modalInstance.close(response);
         });
       }
-
-    }
+    };
   }
 })();

--- a/src/apigility-ui/modal/add-filter.html
+++ b/src/apigility-ui/modal/add-filter.html
@@ -9,10 +9,10 @@
   <ui-select
     ng-model="vm.filter.name"
     on-select="vm.selectFilter($item, $model)">
-    <ui-select-match placeholder="Select Filter...">{{$select.selected.name}}</ui-select-match>
+    <ui-select-match placeholder="Select Filter...">{{$select.selected}}</ui-select-match>
     <ui-select-choices
       repeat="filter in vm.filterNames | filter: $select.search">
-      <div ng-bind-html="filter.name | highlight: $select.search"></div>
+      <div ng-bind-html="filter | highlight: $select.search"></div>
     </ui-select-choices>
   </ui-select>
   <br />
@@ -22,9 +22,9 @@
       <ui-select
         ng-model="vm.option.name"
         on-select="vm.selectOption($item, $model)">
-        <ui-select-match placeholder="Select an option...">{{$select.selected.name}}</ui-select-match>
+        <ui-select-match placeholder="Select an option...">{{$select.selected}}</ui-select-match>
         <ui-select-choices repeat="option in vm.optionNames | filter: $select.search">
-          <div ng-bind-html="option.name | highlight: $select.search"></div>
+          <div ng-bind-html="option | highlight: $select.search"></div>
         </ui-select-choices>
       </ui-select>
     </div>
@@ -39,12 +39,12 @@
       <toggle-switch type="checkbox"
         class="switch-info switch-small"
         model="vm.option.value"
-        ng-show="vm.filter.name && vm.filters[vm.filter.name.name][vm.option.name.name] == 'bool'"></toggle-switch>
+        ng-show="vm.filter.name && vm.filters[vm.filter.name][vm.option.name] == 'bool'"></toggle-switch>
 
       <input type="text" class="form-control"
         ng-model="vm.option.value"
         ng-hide="vm.filter.name && vm.filters[vm.filter.name][vm.option.name] == 'bool'"
-        placeholder="Insert the option value ({{vm.filters[vm.filter.name.name][vm.option.name.name]}})">
+        placeholder="Insert the option value ({{vm.filters[vm.filter.name][vm.option.name]}})">
     </div>
   </div>
   <br /><br />

--- a/src/apigility-ui/modal/add-filter.html
+++ b/src/apigility-ui/modal/add-filter.html
@@ -6,12 +6,27 @@
     <span class="glyphicon glyphicon-exclamation-sign" aria-hidden="true"></span> {{vm.alert}}
   </div>
   <label class="control-label">Filter</label>
-  <select class="form-control" ng-model="vm.filter.name" ng-options="name as name for (name, value) in vm.filters" ng-change="vm.selectFilter()"></select>
+  <ui-select
+    ng-model="vm.filter.name"
+    on-select="vm.selectFilter($item, $model)">
+    <ui-select-match placeholder="Select Filter...">{{$select.selected.name}}</ui-select-match>
+    <ui-select-choices
+      repeat="filter in vm.filterNames | filter: $select.search">
+      <div ng-bind-html="filter.name | highlight: $select.search"></div>
+    </ui-select-choices>
+  </ui-select>
   <br />
   <div class="form-group">
     <label for="rest_validator_option" class="col-sm-2 control-label">Option</label>
     <div class="col-sm-8">
-      <select class="form-control" ng-model="vm.option.name" ng-options="name as name for (name, value) in vm.options" ng-change="vm.option.value=''"></select>
+      <ui-select
+        ng-model="vm.option.name"
+        on-select="vm.selectOption($item, $model)">
+        <ui-select-match placeholder="Select an option...">{{$select.selected.name}}</ui-select-match>
+        <ui-select-choices repeat="option in vm.optionNames | filter: $select.search">
+          <div ng-bind-html="option.name | highlight: $select.search"></div>
+        </ui-select-choices>
+      </ui-select>
     </div>
     <div class="col-sm-2">
       <button type="button" class="btn btn-success btn-sm" ng-click="vm.addOption()">Add option</span></button>
@@ -24,12 +39,12 @@
       <toggle-switch type="checkbox"
         class="switch-info switch-small"
         model="vm.option.value"
-        ng-show="vm.filter.name && vm.filters[vm.filter.name][vm.option.name] == 'bool'"></toggle-switch>
+        ng-show="vm.filter.name && vm.filters[vm.filter.name.name][vm.option.name.name] == 'bool'"></toggle-switch>
 
       <input type="text" class="form-control"
         ng-model="vm.option.value"
         ng-hide="vm.filter.name && vm.filters[vm.filter.name][vm.option.name] == 'bool'"
-        placeholder="Insert the option value ({{vm.filters[vm.filter.name][vm.option.name]}})">
+        placeholder="Insert the option value ({{vm.filters[vm.filter.name.name][vm.option.name.name]}})">
     </div>
   </div>
   <br /><br />

--- a/src/apigility-ui/modal/add-validator.controller.js
+++ b/src/apigility-ui/modal/add-validator.controller.js
@@ -14,6 +14,9 @@
     vm.apiName = $stateParams.api;
     vm.version = $stateParams.ver;
     vm.field = field;
+    vm.validators = {};
+    vm.validatorNames = [];
+    vm.optionNames = [];
 
     vm.cancel = $modalInstance.dismiss;
     vm.validator = { name : '', options : {} };
@@ -29,27 +32,42 @@
       for (var property in result) {
         if (fieldValidators.indexOf(property) > -1) {
           delete vm.validators[property];
+          continue;
         }
+        vm.validatorNames.push({ name: property });
       }
     });
 
-    vm.selectValidator = function() {
-      vm.options = vm.validators[vm.validator.name];
-    }
+    vm.selectValidator = function(item, model) {
+      vm.options = vm.validators[item.name];
+      vm.optionNames = [];
+      for (var property in vm.options) {
+        vm.optionNames.push({ name: property });
+      }
+    };
+
+    vm.selectOption = function(item, model) {
+      console.log('Validator', vm.validator);
+      console.log('Option', vm.option);
+      vm.option.value = '';
+    };
 
     vm.addOption = function() {
-      if (!vm.validator.options.hasOwnProperty(vm.option.name)) {
-        vm.validator.options[vm.option.name] = vm.option.value;
+      /* since option.name is a model, it's nested; pull nested name */
+      if (!vm.validator.options.hasOwnProperty(vm.option.name.name)) {
+        vm.validator.options[vm.option.name.name] = vm.option.value;
       }
-    }
+    };
 
     vm.deleteOption = function(option) {
       if (vm.validator.options.hasOwnProperty(option)) {
         delete vm.validator.options[option];
       }
-    }
+    };
 
     function addValidator(fields, field, validator){
+      /* since validator.name is a model, it's nested; pull nested name */
+      validator.name = validator.name.name;
       for(var i = 0; i < fields.length; i++) {
         if (fields[i].name == field.name) {
           fields[i].validators.push(validator);
@@ -81,7 +99,6 @@
           $modalInstance.close(response);
         });
       }
-
-    }
+    };
   }
 })();

--- a/src/apigility-ui/modal/add-validator.controller.js
+++ b/src/apigility-ui/modal/add-validator.controller.js
@@ -34,28 +34,25 @@
           delete vm.validators[property];
           continue;
         }
-        vm.validatorNames.push({ name: property });
+        vm.validatorNames.push(property);
       }
     });
 
     vm.selectValidator = function(item, model) {
-      vm.options = vm.validators[item.name];
+      vm.options = vm.validators[item];
       vm.optionNames = [];
       for (var property in vm.options) {
-        vm.optionNames.push({ name: property });
+        vm.optionNames.push(property);
       }
     };
 
     vm.selectOption = function(item, model) {
-      console.log('Validator', vm.validator);
-      console.log('Option', vm.option);
       vm.option.value = '';
     };
 
     vm.addOption = function() {
-      /* since option.name is a model, it's nested; pull nested name */
-      if (!vm.validator.options.hasOwnProperty(vm.option.name.name)) {
-        vm.validator.options[vm.option.name.name] = vm.option.value;
+      if (!vm.validator.options.hasOwnProperty(vm.option.name)) {
+        vm.validator.options[vm.option.name] = vm.option.value;
       }
     };
 
@@ -66,8 +63,6 @@
     };
 
     function addValidator(fields, field, validator){
-      /* since validator.name is a model, it's nested; pull nested name */
-      validator.name = validator.name.name;
       for(var i = 0; i < fields.length; i++) {
         if (fields[i].name == field.name) {
           fields[i].validators.push(validator);

--- a/src/apigility-ui/modal/add-validator.html
+++ b/src/apigility-ui/modal/add-validator.html
@@ -6,12 +6,27 @@
     <span class="glyphicon glyphicon-exclamation-sign" aria-hidden="true"></span> {{vm.alert}}
   </div>
   <label class="control-label">Validator</label>
-  <select class="form-control" ng-model="vm.validator.name" ng-options="name as name for (name, value) in vm.validators" ng-change="vm.selectValidator()"></select>
+  <ui-select
+    ng-model="vm.validator.name"
+    on-select="vm.selectValidator($item, $model)">
+    <ui-select-match placeholder="Select Validator...">{{$select.selected.name}}</ui-select-match>
+    <ui-select-choices
+      repeat="validator in vm.validatorNames | filter: $select.search">
+      <div ng-bind-html="validator.name | highlight: $select.search"></div>
+    </ui-select-choices>
+  </ui-select>
   <br />
   <div class="form-group">
     <label for="rest_validator_option" class="col-sm-2 control-label">Option</label>
     <div class="col-sm-8">
-      <select class="form-control" ng-model="vm.option.name" ng-options="name as name for (name, value) in vm.options" ng-change="vm.option.value=''"></select>
+      <ui-select
+        ng-model="vm.option.name"
+        on-select="vm.selectOption($item, $model)">
+        <ui-select-match placeholder="Select an option...">{{$select.selected.name}}</ui-select-match>
+        <ui-select-choices repeat="option in vm.optionNames | filter: $select.search">
+          <div ng-bind-html="option.name | highlight: $select.search"></div>
+        </ui-select-choices>
+      </ui-select>
     </div>
     <div class="col-sm-2">
       <button type="button" class="btn btn-success btn-sm" ng-click="vm.addOption()">Add option</span></button>
@@ -24,12 +39,12 @@
       <toggle-switch type="checkbox"
         class="switch-info switch-small"
         model="vm.option.value"
-        ng-show="vm.validator.name && vm.validators[vm.validator.name][vm.option.name] == 'bool'"></toggle-switch>
+        ng-show="vm.validator.name && vm.validators[vm.validator.name.name][vm.option.name.name] == 'bool'"></toggle-switch>
 
       <input type="text" class="form-control"
         ng-model="vm.option.value"
-        ng-hide="vm.validator.name && vm.validators[vm.validator.name][vm.option.name] == 'bool'"
-        placeholder="Insert the option value ({{vm.validators[vm.validator.name][vm.option.name]}})">
+        ng-hide="vm.validator.name && vm.validators[vm.validator.name.name][vm.option.name.name] == 'bool'"
+        placeholder="Insert the option value ({{vm.validators[vm.validator.name.name][vm.option.name.name]}})">
     </div>
   </div>
   <br /><br />

--- a/src/apigility-ui/modal/add-validator.html
+++ b/src/apigility-ui/modal/add-validator.html
@@ -9,10 +9,10 @@
   <ui-select
     ng-model="vm.validator.name"
     on-select="vm.selectValidator($item, $model)">
-    <ui-select-match placeholder="Select Validator...">{{$select.selected.name}}</ui-select-match>
+    <ui-select-match placeholder="Select Validator...">{{$select.selected}}</ui-select-match>
     <ui-select-choices
       repeat="validator in vm.validatorNames | filter: $select.search">
-      <div ng-bind-html="validator.name | highlight: $select.search"></div>
+      <div ng-bind-html="validator | highlight: $select.search"></div>
     </ui-select-choices>
   </ui-select>
   <br />
@@ -22,9 +22,9 @@
       <ui-select
         ng-model="vm.option.name"
         on-select="vm.selectOption($item, $model)">
-        <ui-select-match placeholder="Select an option...">{{$select.selected.name}}</ui-select-match>
+        <ui-select-match placeholder="Select an option...">{{$select.selected}}</ui-select-match>
         <ui-select-choices repeat="option in vm.optionNames | filter: $select.search">
-          <div ng-bind-html="option.name | highlight: $select.search"></div>
+          <div ng-bind-html="option | highlight: $select.search"></div>
         </ui-select-choices>
       </ui-select>
     </div>
@@ -39,12 +39,12 @@
       <toggle-switch type="checkbox"
         class="switch-info switch-small"
         model="vm.option.value"
-        ng-show="vm.validator.name && vm.validators[vm.validator.name.name][vm.option.name.name] == 'bool'"></toggle-switch>
+        ng-show="vm.validator.name && vm.validators[vm.validator.name][vm.option.name] == 'bool'"></toggle-switch>
 
       <input type="text" class="form-control"
         ng-model="vm.option.value"
-        ng-hide="vm.validator.name && vm.validators[vm.validator.name.name][vm.option.name.name] == 'bool'"
-        placeholder="Insert the option value ({{vm.validators[vm.validator.name.name][vm.option.name.name]}})">
+        ng-hide="vm.validator.name && vm.validators[vm.validator.name][vm.option.name] == 'bool'"
+        placeholder="Insert the option value ({{vm.validators[vm.validator.name][vm.option.name]}})">
     </div>
   </div>
   <br /><br />

--- a/src/apigility-ui/modal/edit-filter.controller.js
+++ b/src/apigility-ui/modal/edit-filter.controller.js
@@ -34,14 +34,13 @@
       vm.options = result[vm.filter.name];
       vm.optionNames = [];
       for (var property in vm.options) {
-        vm.optionNames.push({ name: property });
+        vm.optionNames.push(property);
       }
     });
 
     vm.addOption = function() {
-      /* since option.name is a model, it's nested; pull nested name */
-      if (!vm.filter.options.hasOwnProperty(vm.option.name.name)) {
-        vm.filter.options[vm.option.name.name] = vm.option.value;
+      if (!vm.filter.options.hasOwnProperty(vm.option.name)) {
+        vm.filter.options[vm.option.name] = vm.option.value;
       }
     };
 

--- a/src/apigility-ui/modal/edit-filter.controller.js
+++ b/src/apigility-ui/modal/edit-filter.controller.js
@@ -16,13 +16,15 @@
     vm.apiName = $stateParams.api;
     vm.version = $stateParams.ver;
     vm.field = field;
+    vm.options = {};
+    vm.optionNames = [];
     vm.disabled = !SidebarService.isLastVersion(vm.version, vm.apiName);
 
     vm.cancel = $modalInstance.dismiss;
 
     vm.filter = angular.copy(filter);
     // If options is empty array change it in empty object
-    if (vm.filter.options.length == 0) {
+    if (vm.filter.options.length === 0) {
       vm.filter.options = {};
     }
 
@@ -30,19 +32,24 @@
     api.getFilters(function(result){
       vm.filters = result;
       vm.options = result[vm.filter.name];
+      vm.optionNames = [];
+      for (var property in vm.options) {
+        vm.optionNames.push({ name: property });
+      }
     });
 
     vm.addOption = function() {
-      if (!vm.filter.options.hasOwnProperty(vm.option.name)) {
-        vm.filter.options[vm.option.name] = vm.option.value;
+      /* since option.name is a model, it's nested; pull nested name */
+      if (!vm.filter.options.hasOwnProperty(vm.option.name.name)) {
+        vm.filter.options[vm.option.name.name] = vm.option.value;
       }
-    }
+    };
 
     vm.deleteOption = function(option) {
       if (vm.filter.options.hasOwnProperty(option)) {
         delete vm.filter.options[option];
       }
-    }
+    };
 
     vm.deleteFilterModal = function() {
       var modalInstance = $modal.open({
@@ -85,7 +92,6 @@
     }
 
     vm.ok = function() {
-      vm.loading = true;
       var newFields = angular.copy(fields);
       updateFilter(newFields, field, vm.filter);
       if (type === 'rest') {
@@ -107,6 +113,6 @@
           $modalInstance.close(response);
         });
       }
-    }
+    };
   }
 })();

--- a/src/apigility-ui/modal/edit-filter.html
+++ b/src/apigility-ui/modal/edit-filter.html
@@ -11,7 +11,15 @@
   <div class="form-group">
     <label class="col-sm-2 control-label">Option</label>
     <div class="col-sm-8">
-      <select class="form-control" ng-model="vm.option.name" ng-options="name as name for (name, value) in vm.options" ng-change="vm.option.value=''" ng-disabled="vm.disabled"></select>
+      <ui-select
+        ng-model="vm.option.name"
+        ng-disabled="vm.disabled"
+        on-select="vm.selectOption($item, $model)">
+        <ui-select-match placeholder="Select an option...">{{$select.selected.name}}</ui-select-match>
+        <ui-select-choices repeat="option in vm.optionNames | filter: $select.search">
+          <div ng-bind-html="option.name | highlight: $select.search"></div>
+        </ui-select-choices>
+      </ui-select>
     </div>
     <div class="col-sm-2">
       <button type="button" class="btn btn-success btn-sm" ng-click="vm.addOption()" ng-hide="vm.disabled">Add option</span></button>
@@ -25,13 +33,13 @@
         class="switch-info switch-small"
         model="vm.option.value"
         ng-disabled="vm.disabled"
-        ng-show="vm.filter.name && vm.filters[vm.filter.name][vm.option.name] == 'bool'"></toggle-switch>
+        ng-show="vm.filter.name && vm.filters[vm.filter.name][vm.option.name.name] == 'bool'"></toggle-switch>
 
       <input type="text" class="form-control"
         ng-model="vm.option.value"
         ng-hide="vm.filter.name && vm.filters[vm.filter.name][vm.option.name] == 'bool'"
         ng-disabled="vm.disabled"
-        placeholder="Insert the option value ({{vm.filters[vm.filter.name][vm.option.name]}})">
+        placeholder="Insert the option value ({{vm.filters[vm.filter.name][vm.option.name.name]}})">
     </div>
   </div>
   <br /><br />

--- a/src/apigility-ui/modal/edit-filter.html
+++ b/src/apigility-ui/modal/edit-filter.html
@@ -15,9 +15,9 @@
         ng-model="vm.option.name"
         ng-disabled="vm.disabled"
         on-select="vm.selectOption($item, $model)">
-        <ui-select-match placeholder="Select an option...">{{$select.selected.name}}</ui-select-match>
+        <ui-select-match placeholder="Select an option...">{{$select.selected}}</ui-select-match>
         <ui-select-choices repeat="option in vm.optionNames | filter: $select.search">
-          <div ng-bind-html="option.name | highlight: $select.search"></div>
+          <div ng-bind-html="option | highlight: $select.search"></div>
         </ui-select-choices>
       </ui-select>
     </div>
@@ -33,13 +33,13 @@
         class="switch-info switch-small"
         model="vm.option.value"
         ng-disabled="vm.disabled"
-        ng-show="vm.filter.name && vm.filters[vm.filter.name][vm.option.name.name] == 'bool'"></toggle-switch>
+        ng-show="vm.filter.name && vm.filters[vm.filter.name][vm.option.name] == 'bool'"></toggle-switch>
 
       <input type="text" class="form-control"
         ng-model="vm.option.value"
         ng-hide="vm.filter.name && vm.filters[vm.filter.name][vm.option.name] == 'bool'"
         ng-disabled="vm.disabled"
-        placeholder="Insert the option value ({{vm.filters[vm.filter.name][vm.option.name.name]}})">
+        placeholder="Insert the option value ({{vm.filters[vm.filter.name][vm.option.name]}})">
     </div>
   </div>
   <br /><br />

--- a/src/apigility-ui/modal/edit-validator.controller.js
+++ b/src/apigility-ui/modal/edit-validator.controller.js
@@ -34,14 +34,13 @@
       vm.options = result[vm.validator.name];
       vm.optionNames = [];
       for (var property in vm.options) {
-        vm.optionNames.push({ name: property });
+        vm.optionNames.push(property);
       }
     });
 
     vm.addOption = function() {
-      /* since option.name is a model, it's nested; pull nested name */
-      if (!vm.validator.options.hasOwnProperty(vm.option.name.name)) {
-        vm.validator.options[vm.option.name.name] = vm.option.value;
+      if (!vm.validator.options.hasOwnProperty(vm.option.name)) {
+        vm.validator.options[vm.option.name] = vm.option.value;
       }
     };
 

--- a/src/apigility-ui/modal/edit-validator.controller.js
+++ b/src/apigility-ui/modal/edit-validator.controller.js
@@ -16,13 +16,15 @@
     vm.version = $stateParams.ver;
     vm.restName = $stateParams.rest;
     vm.field = field;
+    vm.options = {};
+    vm.optionNames = [];
     vm.disabled = !SidebarService.isLastVersion(vm.version, vm.apiName);
 
     vm.cancel = $modalInstance.dismiss;
 
     vm.validator = angular.copy(validator);
     // If options is empty array change it in empty object
-    if (vm.validator.options.length == 0) {
+    if (vm.validator.options.length === 0) {
       vm.validator.options = {};
     }
 
@@ -30,19 +32,24 @@
     api.getValidators(function(result){
       vm.validators = result;
       vm.options = result[vm.validator.name];
+      vm.optionNames = [];
+      for (var property in vm.options) {
+        vm.optionNames.push({ name: property });
+      }
     });
 
     vm.addOption = function() {
-      if (!vm.validator.options.hasOwnProperty(vm.option.name)) {
-        vm.validator.options[vm.option.name] = vm.option.value;
+      /* since option.name is a model, it's nested; pull nested name */
+      if (!vm.validator.options.hasOwnProperty(vm.option.name.name)) {
+        vm.validator.options[vm.option.name.name] = vm.option.value;
       }
-    }
+    };
 
     vm.deleteOption = function(option) {
       if (vm.validator.options.hasOwnProperty(option)) {
         delete vm.validator.options[option];
       }
-    }
+    };
 
     vm.deleteValidatorModal = function() {
       var modalInstance = $modal.open({
@@ -107,7 +114,6 @@
           $modalInstance.close(response);
         });
       }
-
-    }
+    };
   }
 })();

--- a/src/apigility-ui/modal/edit-validator.html
+++ b/src/apigility-ui/modal/edit-validator.html
@@ -11,7 +11,15 @@
   <div class="form-group">
     <label for="rest_validator_option" class="col-sm-2 control-label">Option</label>
     <div class="col-sm-8">
-      <select class="form-control" ng-model="vm.option.name" ng-options="name as name for (name, value) in vm.options" ng-change="vm.option.value=''" ng-disabled="vm.disabled"></select>
+      <ui-select
+        ng-model="vm.option.name"
+        ng-disabled="vm.disabled"
+        on-select="vm.selectOption($item, $model)">
+        <ui-select-match placeholder="Select an option...">{{$select.selected.name}}</ui-select-match>
+        <ui-select-choices repeat="option in vm.optionNames | filter: $select.search">
+          <div ng-bind-html="option.name | highlight: $select.search"></div>
+        </ui-select-choices>
+      </ui-select>
     </div>
     <div class="col-sm-2">
       <button type="button" class="btn btn-success btn-sm" ng-click="vm.addOption()" ng-hide="vm.disabled">Add option</span></button>
@@ -24,13 +32,13 @@
       <toggle-switch type="checkbox"
         model="vm.option.value"
         ng-disabled="vm.disabled"
-        ng-show="vm.validator.name && vm.validators[vm.validator.name][vm.option.name] == 'bool'"></toggle-switch>
+        ng-show="vm.validator.name && vm.validators[vm.validator.name][vm.option.name.name] == 'bool'"></toggle-switch>
 
       <input type="text" class="form-control"
         ng-model="vm.option.value"
-        ng-hide="vm.validator.name && vm.validators[vm.validator.name][vm.option.name] == 'bool'"
+        ng-hide="vm.validator.name && vm.validators[vm.validator.name][vm.option.name.name] == 'bool'"
         ng-disabled="vm.disabled"
-        placeholder="Insert the option value ({{vm.validators[vm.validator.name][vm.option.name]}})">
+        placeholder="Insert the option value ({{vm.validators[vm.validator.name][vm.option.name.name]}})">
     </div>
   </div>
   <br /><br />

--- a/src/apigility-ui/modal/edit-validator.html
+++ b/src/apigility-ui/modal/edit-validator.html
@@ -15,9 +15,9 @@
         ng-model="vm.option.name"
         ng-disabled="vm.disabled"
         on-select="vm.selectOption($item, $model)">
-        <ui-select-match placeholder="Select an option...">{{$select.selected.name}}</ui-select-match>
+        <ui-select-match placeholder="Select an option...">{{$select.selected}}</ui-select-match>
         <ui-select-choices repeat="option in vm.optionNames | filter: $select.search">
-          <div ng-bind-html="option.name | highlight: $select.search"></div>
+          <div ng-bind-html="option | highlight: $select.search"></div>
         </ui-select-choices>
       </ui-select>
     </div>
@@ -32,13 +32,13 @@
       <toggle-switch type="checkbox"
         model="vm.option.value"
         ng-disabled="vm.disabled"
-        ng-show="vm.validator.name && vm.validators[vm.validator.name][vm.option.name.name] == 'bool'"></toggle-switch>
+        ng-show="vm.validator.name && vm.validators[vm.validator.name][vm.option.name] == 'bool'"></toggle-switch>
 
       <input type="text" class="form-control"
         ng-model="vm.option.value"
-        ng-hide="vm.validator.name && vm.validators[vm.validator.name][vm.option.name.name] == 'bool'"
+        ng-hide="vm.validator.name && vm.validators[vm.validator.name][vm.option.name] == 'bool'"
         ng-disabled="vm.disabled"
-        placeholder="Insert the option value ({{vm.validators[vm.validator.name][vm.option.name.name]}})">
+        placeholder="Insert the option value ({{vm.validators[vm.validator.name][vm.option.name]}})">
     </div>
   </div>
   <br /><br />

--- a/src/apigility-ui/rest/rest.controller.js
+++ b/src/apigility-ui/rest/rest.controller.js
@@ -39,6 +39,7 @@
 
       api.getRest(vm.apiName, vm.version, vm.restName, function(result){
         vm.rest = result;
+        console.log(vm.rest);
         vm.isDoctrine = angular.isDefined(result.object_manager);
 
         vm.rest.accept_whitelist.forEach(function(entry){
@@ -49,7 +50,7 @@
         });
 
         if (vm.isDoctrine) {
-          if (vm.rest.strategies.length == 0) {
+          if (vm.rest.strategies.length === 0) {
             vm.rest.strategies = {};
           }
           api.getRestDoctrineMetadata(result.object_manager, result.entity_class, function(err, response) {
@@ -60,7 +61,8 @@
             vm.doctrineMetadata = response;
           });
         }
-        if (vm.rest.hasOwnProperty('table_name')) {
+        if (vm.rest.hasOwnProperty('table_name') &&
+            vm.rest.hasOwnProperty('db')) {
           for (var i = 0; i < vm.db.db_adapter.length; i++) {
             if (vm.db.db_adapter[i].adapter_name == vm.rest.adapter_name) {
               vm.adapter = vm.db.db_adapter[i];
@@ -95,6 +97,9 @@
       });
     }
 
+    vm.selectHydrator = function($item, $model) {
+    };
+
     function initAuthorization() {
       api.getAuthorizationRest(vm.apiName, vm.version, vm.restName, function(err, result){
         if (err) {
@@ -112,6 +117,9 @@
       vm.loading = true;
       if (vm.adapter) {
         vm.rest.adapter_name = vm.adapter.adapter_name;
+      }
+      if (vm.rest.hydrator_name.name) {
+        vm.rest.hydrator_name = vm.rest.hydrator_name.name;
       }
       api.updateGeneralRest(vm.apiName, vm.version, vm.restName, vm.rest, vm.isDoctrine, function(err, result){
         vm.loading = false;
@@ -154,7 +162,7 @@
       }
 
       return false;
-    }
+    };
 
     vm.saveContentNegotiation = function() {
       vm.loading = true;

--- a/src/apigility-ui/rest/rest.controller.js
+++ b/src/apigility-ui/rest/rest.controller.js
@@ -39,7 +39,6 @@
 
       api.getRest(vm.apiName, vm.version, vm.restName, function(result){
         vm.rest = result;
-        console.log(vm.rest);
         vm.isDoctrine = angular.isDefined(result.object_manager);
 
         vm.rest.accept_whitelist.forEach(function(entry){

--- a/src/apigility-ui/rest/rest.html
+++ b/src/apigility-ui/rest/rest.html
@@ -67,7 +67,15 @@
             <div class="form-group" ng-if="!vm.isDoctrine">
               <label for="rest_hydrator" class="col-sm-2 control-label">Hydrator Service Name</label>
               <div class="col-sm-4">
-                <select class="form-control" ng-model="vm.rest.hydrator_name" ng-options="hydrator for hydrator in vm.hydrators" ng-disabled="vm.disabled"></select>
+                <ui-select
+                  ng-model="vm.rest.hydrator_name"
+                  ng-disabled="vm.disabled">
+                  <ui-select-match placeholder="Select Hydrator...">{{$select.selected}}</ui-select-match>
+                  <ui-select-choices
+                    repeat="hydrator in vm.hydrators | filter: $select.search">
+                    <div ng-bind-html="hydrator | highlight: $select.search"></div>
+                  </ui-select-choices>
+                </ui-select>
               </div>
             </div>
             <div class="form-group">

--- a/src/apigility-ui/templates.js
+++ b/src/apigility-ui/templates.js
@@ -511,10 +511,10 @@ angular.module("apigility-ui/modal/add-filter.html", []).run(["$templateCache", 
     "  <ui-select\n" +
     "    ng-model=\"vm.filter.name\"\n" +
     "    on-select=\"vm.selectFilter($item, $model)\">\n" +
-    "    <ui-select-match placeholder=\"Select Filter...\">{{$select.selected.name}}</ui-select-match>\n" +
+    "    <ui-select-match placeholder=\"Select Filter...\">{{$select.selected}}</ui-select-match>\n" +
     "    <ui-select-choices\n" +
     "      repeat=\"filter in vm.filterNames | filter: $select.search\">\n" +
-    "      <div ng-bind-html=\"filter.name | highlight: $select.search\"></div>\n" +
+    "      <div ng-bind-html=\"filter | highlight: $select.search\"></div>\n" +
     "    </ui-select-choices>\n" +
     "  </ui-select>\n" +
     "  <br />\n" +
@@ -524,9 +524,9 @@ angular.module("apigility-ui/modal/add-filter.html", []).run(["$templateCache", 
     "      <ui-select\n" +
     "        ng-model=\"vm.option.name\"\n" +
     "        on-select=\"vm.selectOption($item, $model)\">\n" +
-    "        <ui-select-match placeholder=\"Select an option...\">{{$select.selected.name}}</ui-select-match>\n" +
+    "        <ui-select-match placeholder=\"Select an option...\">{{$select.selected}}</ui-select-match>\n" +
     "        <ui-select-choices repeat=\"option in vm.optionNames | filter: $select.search\">\n" +
-    "          <div ng-bind-html=\"option.name | highlight: $select.search\"></div>\n" +
+    "          <div ng-bind-html=\"option | highlight: $select.search\"></div>\n" +
     "        </ui-select-choices>\n" +
     "      </ui-select>\n" +
     "    </div>\n" +
@@ -541,12 +541,12 @@ angular.module("apigility-ui/modal/add-filter.html", []).run(["$templateCache", 
     "      <toggle-switch type=\"checkbox\"\n" +
     "        class=\"switch-info switch-small\"\n" +
     "        model=\"vm.option.value\"\n" +
-    "        ng-show=\"vm.filter.name && vm.filters[vm.filter.name.name][vm.option.name.name] == 'bool'\"></toggle-switch>\n" +
+    "        ng-show=\"vm.filter.name && vm.filters[vm.filter.name][vm.option.name] == 'bool'\"></toggle-switch>\n" +
     "\n" +
     "      <input type=\"text\" class=\"form-control\"\n" +
     "        ng-model=\"vm.option.value\"\n" +
     "        ng-hide=\"vm.filter.name && vm.filters[vm.filter.name][vm.option.name] == 'bool'\"\n" +
-    "        placeholder=\"Insert the option value ({{vm.filters[vm.filter.name.name][vm.option.name.name]}})\">\n" +
+    "        placeholder=\"Insert the option value ({{vm.filters[vm.filter.name][vm.option.name]}})\">\n" +
     "    </div>\n" +
     "  </div>\n" +
     "  <br /><br />\n" +
@@ -591,10 +591,10 @@ angular.module("apigility-ui/modal/add-validator.html", []).run(["$templateCache
     "  <ui-select\n" +
     "    ng-model=\"vm.validator.name\"\n" +
     "    on-select=\"vm.selectValidator($item, $model)\">\n" +
-    "    <ui-select-match placeholder=\"Select Validator...\">{{$select.selected.name}}</ui-select-match>\n" +
+    "    <ui-select-match placeholder=\"Select Validator...\">{{$select.selected}}</ui-select-match>\n" +
     "    <ui-select-choices\n" +
     "      repeat=\"validator in vm.validatorNames | filter: $select.search\">\n" +
-    "      <div ng-bind-html=\"validator.name | highlight: $select.search\"></div>\n" +
+    "      <div ng-bind-html=\"validator | highlight: $select.search\"></div>\n" +
     "    </ui-select-choices>\n" +
     "  </ui-select>\n" +
     "  <br />\n" +
@@ -604,9 +604,9 @@ angular.module("apigility-ui/modal/add-validator.html", []).run(["$templateCache
     "      <ui-select\n" +
     "        ng-model=\"vm.option.name\"\n" +
     "        on-select=\"vm.selectOption($item, $model)\">\n" +
-    "        <ui-select-match placeholder=\"Select an option...\">{{$select.selected.name}}</ui-select-match>\n" +
+    "        <ui-select-match placeholder=\"Select an option...\">{{$select.selected}}</ui-select-match>\n" +
     "        <ui-select-choices repeat=\"option in vm.optionNames | filter: $select.search\">\n" +
-    "          <div ng-bind-html=\"option.name | highlight: $select.search\"></div>\n" +
+    "          <div ng-bind-html=\"option | highlight: $select.search\"></div>\n" +
     "        </ui-select-choices>\n" +
     "      </ui-select>\n" +
     "    </div>\n" +
@@ -621,12 +621,12 @@ angular.module("apigility-ui/modal/add-validator.html", []).run(["$templateCache
     "      <toggle-switch type=\"checkbox\"\n" +
     "        class=\"switch-info switch-small\"\n" +
     "        model=\"vm.option.value\"\n" +
-    "        ng-show=\"vm.validator.name && vm.validators[vm.validator.name.name][vm.option.name.name] == 'bool'\"></toggle-switch>\n" +
+    "        ng-show=\"vm.validator.name && vm.validators[vm.validator.name][vm.option.name] == 'bool'\"></toggle-switch>\n" +
     "\n" +
     "      <input type=\"text\" class=\"form-control\"\n" +
     "        ng-model=\"vm.option.value\"\n" +
-    "        ng-hide=\"vm.validator.name && vm.validators[vm.validator.name.name][vm.option.name.name] == 'bool'\"\n" +
-    "        placeholder=\"Insert the option value ({{vm.validators[vm.validator.name.name][vm.option.name.name]}})\">\n" +
+    "        ng-hide=\"vm.validator.name && vm.validators[vm.validator.name][vm.option.name] == 'bool'\"\n" +
+    "        placeholder=\"Insert the option value ({{vm.validators[vm.validator.name][vm.option.name]}})\">\n" +
     "    </div>\n" +
     "  </div>\n" +
     "  <br /><br />\n" +
@@ -1123,9 +1123,9 @@ angular.module("apigility-ui/modal/edit-filter.html", []).run(["$templateCache",
     "        ng-model=\"vm.option.name\"\n" +
     "        ng-disabled=\"vm.disabled\"\n" +
     "        on-select=\"vm.selectOption($item, $model)\">\n" +
-    "        <ui-select-match placeholder=\"Select an option...\">{{$select.selected.name}}</ui-select-match>\n" +
+    "        <ui-select-match placeholder=\"Select an option...\">{{$select.selected}}</ui-select-match>\n" +
     "        <ui-select-choices repeat=\"option in vm.optionNames | filter: $select.search\">\n" +
-    "          <div ng-bind-html=\"option.name | highlight: $select.search\"></div>\n" +
+    "          <div ng-bind-html=\"option | highlight: $select.search\"></div>\n" +
     "        </ui-select-choices>\n" +
     "      </ui-select>\n" +
     "    </div>\n" +
@@ -1141,13 +1141,13 @@ angular.module("apigility-ui/modal/edit-filter.html", []).run(["$templateCache",
     "        class=\"switch-info switch-small\"\n" +
     "        model=\"vm.option.value\"\n" +
     "        ng-disabled=\"vm.disabled\"\n" +
-    "        ng-show=\"vm.filter.name && vm.filters[vm.filter.name][vm.option.name.name] == 'bool'\"></toggle-switch>\n" +
+    "        ng-show=\"vm.filter.name && vm.filters[vm.filter.name][vm.option.name] == 'bool'\"></toggle-switch>\n" +
     "\n" +
     "      <input type=\"text\" class=\"form-control\"\n" +
     "        ng-model=\"vm.option.value\"\n" +
     "        ng-hide=\"vm.filter.name && vm.filters[vm.filter.name][vm.option.name] == 'bool'\"\n" +
     "        ng-disabled=\"vm.disabled\"\n" +
-    "        placeholder=\"Insert the option value ({{vm.filters[vm.filter.name][vm.option.name.name]}})\">\n" +
+    "        placeholder=\"Insert the option value ({{vm.filters[vm.filter.name][vm.option.name]}})\">\n" +
     "    </div>\n" +
     "  </div>\n" +
     "  <br /><br />\n" +
@@ -1198,9 +1198,9 @@ angular.module("apigility-ui/modal/edit-validator.html", []).run(["$templateCach
     "        ng-model=\"vm.option.name\"\n" +
     "        ng-disabled=\"vm.disabled\"\n" +
     "        on-select=\"vm.selectOption($item, $model)\">\n" +
-    "        <ui-select-match placeholder=\"Select an option...\">{{$select.selected.name}}</ui-select-match>\n" +
+    "        <ui-select-match placeholder=\"Select an option...\">{{$select.selected}}</ui-select-match>\n" +
     "        <ui-select-choices repeat=\"option in vm.optionNames | filter: $select.search\">\n" +
-    "          <div ng-bind-html=\"option.name | highlight: $select.search\"></div>\n" +
+    "          <div ng-bind-html=\"option | highlight: $select.search\"></div>\n" +
     "        </ui-select-choices>\n" +
     "      </ui-select>\n" +
     "    </div>\n" +
@@ -1215,13 +1215,13 @@ angular.module("apigility-ui/modal/edit-validator.html", []).run(["$templateCach
     "      <toggle-switch type=\"checkbox\"\n" +
     "        model=\"vm.option.value\"\n" +
     "        ng-disabled=\"vm.disabled\"\n" +
-    "        ng-show=\"vm.validator.name && vm.validators[vm.validator.name][vm.option.name.name] == 'bool'\"></toggle-switch>\n" +
+    "        ng-show=\"vm.validator.name && vm.validators[vm.validator.name][vm.option.name] == 'bool'\"></toggle-switch>\n" +
     "\n" +
     "      <input type=\"text\" class=\"form-control\"\n" +
     "        ng-model=\"vm.option.value\"\n" +
-    "        ng-hide=\"vm.validator.name && vm.validators[vm.validator.name][vm.option.name.name] == 'bool'\"\n" +
+    "        ng-hide=\"vm.validator.name && vm.validators[vm.validator.name][vm.option.name] == 'bool'\"\n" +
     "        ng-disabled=\"vm.disabled\"\n" +
-    "        placeholder=\"Insert the option value ({{vm.validators[vm.validator.name][vm.option.name.name]}})\">\n" +
+    "        placeholder=\"Insert the option value ({{vm.validators[vm.validator.name][vm.option.name]}})\">\n" +
     "    </div>\n" +
     "  </div>\n" +
     "  <br /><br />\n" +

--- a/src/apigility-ui/templates.js
+++ b/src/apigility-ui/templates.js
@@ -1932,7 +1932,15 @@ angular.module("apigility-ui/rest/rest.html", []).run(["$templateCache", functio
     "            <div class=\"form-group\" ng-if=\"!vm.isDoctrine\">\n" +
     "              <label for=\"rest_hydrator\" class=\"col-sm-2 control-label\">Hydrator Service Name</label>\n" +
     "              <div class=\"col-sm-4\">\n" +
-    "                <select class=\"form-control\" ng-model=\"vm.rest.hydrator_name\" ng-options=\"hydrator for hydrator in vm.hydrators\" ng-disabled=\"vm.disabled\"></select>\n" +
+    "                <ui-select\n" +
+    "                  ng-model=\"vm.rest.hydrator_name\"\n" +
+    "                  ng-disabled=\"vm.disabled\">\n" +
+    "                  <ui-select-match placeholder=\"Select Hydrator...\">{{$select.selected}}</ui-select-match>\n" +
+    "                  <ui-select-choices\n" +
+    "                    repeat=\"hydrator in vm.hydrators | filter: $select.search\">\n" +
+    "                    <div ng-bind-html=\"hydrator | highlight: $select.search\"></div>\n" +
+    "                  </ui-select-choices>\n" +
+    "                </ui-select>\n" +
     "              </div>\n" +
     "            </div>\n" +
     "            <div class=\"form-group\">\n" +

--- a/src/apigility-ui/templates.js
+++ b/src/apigility-ui/templates.js
@@ -508,12 +508,27 @@ angular.module("apigility-ui/modal/add-filter.html", []).run(["$templateCache", 
     "    <span class=\"glyphicon glyphicon-exclamation-sign\" aria-hidden=\"true\"></span> {{vm.alert}}\n" +
     "  </div>\n" +
     "  <label class=\"control-label\">Filter</label>\n" +
-    "  <select class=\"form-control\" ng-model=\"vm.filter.name\" ng-options=\"name as name for (name, value) in vm.filters\" ng-change=\"vm.selectFilter()\"></select>\n" +
+    "  <ui-select\n" +
+    "    ng-model=\"vm.filter.name\"\n" +
+    "    on-select=\"vm.selectFilter($item, $model)\">\n" +
+    "    <ui-select-match placeholder=\"Select Filter...\">{{$select.selected.name}}</ui-select-match>\n" +
+    "    <ui-select-choices\n" +
+    "      repeat=\"filter in vm.filterNames | filter: $select.search\">\n" +
+    "      <div ng-bind-html=\"filter.name | highlight: $select.search\"></div>\n" +
+    "    </ui-select-choices>\n" +
+    "  </ui-select>\n" +
     "  <br />\n" +
     "  <div class=\"form-group\">\n" +
     "    <label for=\"rest_validator_option\" class=\"col-sm-2 control-label\">Option</label>\n" +
     "    <div class=\"col-sm-8\">\n" +
-    "      <select class=\"form-control\" ng-model=\"vm.option.name\" ng-options=\"name as name for (name, value) in vm.options\" ng-change=\"vm.option.value=''\"></select>\n" +
+    "      <ui-select\n" +
+    "        ng-model=\"vm.option.name\"\n" +
+    "        on-select=\"vm.selectOption($item, $model)\">\n" +
+    "        <ui-select-match placeholder=\"Select an option...\">{{$select.selected.name}}</ui-select-match>\n" +
+    "        <ui-select-choices repeat=\"option in vm.optionNames | filter: $select.search\">\n" +
+    "          <div ng-bind-html=\"option.name | highlight: $select.search\"></div>\n" +
+    "        </ui-select-choices>\n" +
+    "      </ui-select>\n" +
     "    </div>\n" +
     "    <div class=\"col-sm-2\">\n" +
     "      <button type=\"button\" class=\"btn btn-success btn-sm\" ng-click=\"vm.addOption()\">Add option</span></button>\n" +
@@ -526,12 +541,12 @@ angular.module("apigility-ui/modal/add-filter.html", []).run(["$templateCache", 
     "      <toggle-switch type=\"checkbox\"\n" +
     "        class=\"switch-info switch-small\"\n" +
     "        model=\"vm.option.value\"\n" +
-    "        ng-show=\"vm.filter.name && vm.filters[vm.filter.name][vm.option.name] == 'bool'\"></toggle-switch>\n" +
+    "        ng-show=\"vm.filter.name && vm.filters[vm.filter.name.name][vm.option.name.name] == 'bool'\"></toggle-switch>\n" +
     "\n" +
     "      <input type=\"text\" class=\"form-control\"\n" +
     "        ng-model=\"vm.option.value\"\n" +
     "        ng-hide=\"vm.filter.name && vm.filters[vm.filter.name][vm.option.name] == 'bool'\"\n" +
-    "        placeholder=\"Insert the option value ({{vm.filters[vm.filter.name][vm.option.name]}})\">\n" +
+    "        placeholder=\"Insert the option value ({{vm.filters[vm.filter.name.name][vm.option.name.name]}})\">\n" +
     "    </div>\n" +
     "  </div>\n" +
     "  <br /><br />\n" +
@@ -573,12 +588,27 @@ angular.module("apigility-ui/modal/add-validator.html", []).run(["$templateCache
     "    <span class=\"glyphicon glyphicon-exclamation-sign\" aria-hidden=\"true\"></span> {{vm.alert}}\n" +
     "  </div>\n" +
     "  <label class=\"control-label\">Validator</label>\n" +
-    "  <select class=\"form-control\" ng-model=\"vm.validator.name\" ng-options=\"name as name for (name, value) in vm.validators\" ng-change=\"vm.selectValidator()\"></select>\n" +
+    "  <ui-select\n" +
+    "    ng-model=\"vm.validator.name\"\n" +
+    "    on-select=\"vm.selectValidator($item, $model)\">\n" +
+    "    <ui-select-match placeholder=\"Select Validator...\">{{$select.selected.name}}</ui-select-match>\n" +
+    "    <ui-select-choices\n" +
+    "      repeat=\"validator in vm.validatorNames | filter: $select.search\">\n" +
+    "      <div ng-bind-html=\"validator.name | highlight: $select.search\"></div>\n" +
+    "    </ui-select-choices>\n" +
+    "  </ui-select>\n" +
     "  <br />\n" +
     "  <div class=\"form-group\">\n" +
     "    <label for=\"rest_validator_option\" class=\"col-sm-2 control-label\">Option</label>\n" +
     "    <div class=\"col-sm-8\">\n" +
-    "      <select class=\"form-control\" ng-model=\"vm.option.name\" ng-options=\"name as name for (name, value) in vm.options\" ng-change=\"vm.option.value=''\"></select>\n" +
+    "      <ui-select\n" +
+    "        ng-model=\"vm.option.name\"\n" +
+    "        on-select=\"vm.selectOption($item, $model)\">\n" +
+    "        <ui-select-match placeholder=\"Select an option...\">{{$select.selected.name}}</ui-select-match>\n" +
+    "        <ui-select-choices repeat=\"option in vm.optionNames | filter: $select.search\">\n" +
+    "          <div ng-bind-html=\"option.name | highlight: $select.search\"></div>\n" +
+    "        </ui-select-choices>\n" +
+    "      </ui-select>\n" +
     "    </div>\n" +
     "    <div class=\"col-sm-2\">\n" +
     "      <button type=\"button\" class=\"btn btn-success btn-sm\" ng-click=\"vm.addOption()\">Add option</span></button>\n" +
@@ -591,12 +621,12 @@ angular.module("apigility-ui/modal/add-validator.html", []).run(["$templateCache
     "      <toggle-switch type=\"checkbox\"\n" +
     "        class=\"switch-info switch-small\"\n" +
     "        model=\"vm.option.value\"\n" +
-    "        ng-show=\"vm.validator.name && vm.validators[vm.validator.name][vm.option.name] == 'bool'\"></toggle-switch>\n" +
+    "        ng-show=\"vm.validator.name && vm.validators[vm.validator.name.name][vm.option.name.name] == 'bool'\"></toggle-switch>\n" +
     "\n" +
     "      <input type=\"text\" class=\"form-control\"\n" +
     "        ng-model=\"vm.option.value\"\n" +
-    "        ng-hide=\"vm.validator.name && vm.validators[vm.validator.name][vm.option.name] == 'bool'\"\n" +
-    "        placeholder=\"Insert the option value ({{vm.validators[vm.validator.name][vm.option.name]}})\">\n" +
+    "        ng-hide=\"vm.validator.name && vm.validators[vm.validator.name.name][vm.option.name.name] == 'bool'\"\n" +
+    "        placeholder=\"Insert the option value ({{vm.validators[vm.validator.name.name][vm.option.name.name]}})\">\n" +
     "    </div>\n" +
     "  </div>\n" +
     "  <br /><br />\n" +
@@ -1089,7 +1119,15 @@ angular.module("apigility-ui/modal/edit-filter.html", []).run(["$templateCache",
     "  <div class=\"form-group\">\n" +
     "    <label class=\"col-sm-2 control-label\">Option</label>\n" +
     "    <div class=\"col-sm-8\">\n" +
-    "      <select class=\"form-control\" ng-model=\"vm.option.name\" ng-options=\"name as name for (name, value) in vm.options\" ng-change=\"vm.option.value=''\" ng-disabled=\"vm.disabled\"></select>\n" +
+    "      <ui-select\n" +
+    "        ng-model=\"vm.option.name\"\n" +
+    "        ng-disabled=\"vm.disabled\"\n" +
+    "        on-select=\"vm.selectOption($item, $model)\">\n" +
+    "        <ui-select-match placeholder=\"Select an option...\">{{$select.selected.name}}</ui-select-match>\n" +
+    "        <ui-select-choices repeat=\"option in vm.optionNames | filter: $select.search\">\n" +
+    "          <div ng-bind-html=\"option.name | highlight: $select.search\"></div>\n" +
+    "        </ui-select-choices>\n" +
+    "      </ui-select>\n" +
     "    </div>\n" +
     "    <div class=\"col-sm-2\">\n" +
     "      <button type=\"button\" class=\"btn btn-success btn-sm\" ng-click=\"vm.addOption()\" ng-hide=\"vm.disabled\">Add option</span></button>\n" +
@@ -1103,13 +1141,13 @@ angular.module("apigility-ui/modal/edit-filter.html", []).run(["$templateCache",
     "        class=\"switch-info switch-small\"\n" +
     "        model=\"vm.option.value\"\n" +
     "        ng-disabled=\"vm.disabled\"\n" +
-    "        ng-show=\"vm.filter.name && vm.filters[vm.filter.name][vm.option.name] == 'bool'\"></toggle-switch>\n" +
+    "        ng-show=\"vm.filter.name && vm.filters[vm.filter.name][vm.option.name.name] == 'bool'\"></toggle-switch>\n" +
     "\n" +
     "      <input type=\"text\" class=\"form-control\"\n" +
     "        ng-model=\"vm.option.value\"\n" +
     "        ng-hide=\"vm.filter.name && vm.filters[vm.filter.name][vm.option.name] == 'bool'\"\n" +
     "        ng-disabled=\"vm.disabled\"\n" +
-    "        placeholder=\"Insert the option value ({{vm.filters[vm.filter.name][vm.option.name]}})\">\n" +
+    "        placeholder=\"Insert the option value ({{vm.filters[vm.filter.name][vm.option.name.name]}})\">\n" +
     "    </div>\n" +
     "  </div>\n" +
     "  <br /><br />\n" +
@@ -1156,7 +1194,15 @@ angular.module("apigility-ui/modal/edit-validator.html", []).run(["$templateCach
     "  <div class=\"form-group\">\n" +
     "    <label for=\"rest_validator_option\" class=\"col-sm-2 control-label\">Option</label>\n" +
     "    <div class=\"col-sm-8\">\n" +
-    "      <select class=\"form-control\" ng-model=\"vm.option.name\" ng-options=\"name as name for (name, value) in vm.options\" ng-change=\"vm.option.value=''\" ng-disabled=\"vm.disabled\"></select>\n" +
+    "      <ui-select\n" +
+    "        ng-model=\"vm.option.name\"\n" +
+    "        ng-disabled=\"vm.disabled\"\n" +
+    "        on-select=\"vm.selectOption($item, $model)\">\n" +
+    "        <ui-select-match placeholder=\"Select an option...\">{{$select.selected.name}}</ui-select-match>\n" +
+    "        <ui-select-choices repeat=\"option in vm.optionNames | filter: $select.search\">\n" +
+    "          <div ng-bind-html=\"option.name | highlight: $select.search\"></div>\n" +
+    "        </ui-select-choices>\n" +
+    "      </ui-select>\n" +
     "    </div>\n" +
     "    <div class=\"col-sm-2\">\n" +
     "      <button type=\"button\" class=\"btn btn-success btn-sm\" ng-click=\"vm.addOption()\" ng-hide=\"vm.disabled\">Add option</span></button>\n" +
@@ -1169,13 +1215,13 @@ angular.module("apigility-ui/modal/edit-validator.html", []).run(["$templateCach
     "      <toggle-switch type=\"checkbox\"\n" +
     "        model=\"vm.option.value\"\n" +
     "        ng-disabled=\"vm.disabled\"\n" +
-    "        ng-show=\"vm.validator.name && vm.validators[vm.validator.name][vm.option.name] == 'bool'\"></toggle-switch>\n" +
+    "        ng-show=\"vm.validator.name && vm.validators[vm.validator.name][vm.option.name.name] == 'bool'\"></toggle-switch>\n" +
     "\n" +
     "      <input type=\"text\" class=\"form-control\"\n" +
     "        ng-model=\"vm.option.value\"\n" +
-    "        ng-hide=\"vm.validator.name && vm.validators[vm.validator.name][vm.option.name] == 'bool'\"\n" +
+    "        ng-hide=\"vm.validator.name && vm.validators[vm.validator.name][vm.option.name.name] == 'bool'\"\n" +
     "        ng-disabled=\"vm.disabled\"\n" +
-    "        placeholder=\"Insert the option value ({{vm.validators[vm.validator.name][vm.option.name]}})\">\n" +
+    "        placeholder=\"Insert the option value ({{vm.validators[vm.validator.name][vm.option.name.name]}})\">\n" +
     "    </div>\n" +
     "  </div>\n" +
     "  <br /><br />\n" +

--- a/src/index.html
+++ b/src/index.html
@@ -22,6 +22,7 @@
     <link href="vendor/ng-tags-input/ng-tags-input.min.css" rel="stylesheet">
     <link href="vendor/ng-tags-input/ng-tags-input.bootstrap.min.css" rel="stylesheet">
     <link href="vendor/angular-bootstrap-toggle-switch/style/bootstrap3/angular-toggle-switch-bootstrap-3.css" rel="stylesheet">
+    <link href="vendor/angular-ui-select/dist/select.css" rel="stylesheet">
     <link href="vendor/angular-ui-tree/dist/angular-ui-tree.min.css" rel="stylesheet">
     <link href="vendor/ladda/dist/ladda-themeless.min.css" rel="stylesheet">
 
@@ -57,10 +58,12 @@
     <!-- build:js apigility-ui/vendor.js -->
     <script src="vendor/jquery/dist/jquery.min.js"></script>
     <script src="vendor/angular/angular.js"></script>
+    <script src="vendor/angular-sanitize/angular-sanitize.js"></script>
     <script src="vendor/angular-ui-bootstrap-bower/ui-bootstrap-tpls.min.js"></script>
     <script src="vendor/angular-ui-router/release/angular-ui-router.min.js"></script>
     <script src="vendor/ng-tags-input/ng-tags-input.min.js"></script>
     <script src="vendor/angular-bootstrap-toggle-switch/angular-toggle-switch.js"></script>
+    <script src="vendor/angular-ui-select/dist/select.js"></script>
     <script src="vendor/angular-local-storage/dist/angular-local-storage.min.js"></script>
     <script src="vendor/humps/humps.js"></script>
     <script src="vendor/angular-ui-tree/dist/angular-ui-tree.min.js"></script>


### PR DESCRIPTION
One feature of Apigility 1.0 was that filters, validators, and hydrators were implemented as ui-select elements, allowing the ability to "type to select" from large lists of options. This patch re-implements that for each of those items, using an updated ui-select for Bootstrap 3.