### PR TITLE
Ensure only the selector name is transmitted to the API

### DIFF
--- a/src/apigility-ui/rest/rest.controller.js
+++ b/src/apigility-ui/rest/rest.controller.js
@@ -17,6 +17,7 @@
     vm.restName = $stateParams.rest;
     vm.httpMethods = [ 'GET', 'POST', 'PUT', 'PATCH', 'DELETE'];
     vm.disabled = !SidebarService.isLastVersion(vm.version, vm.apiName);
+    vm.selectorNames = [];
 
     function initGeneral() {
       vm.tags = {
@@ -84,13 +85,8 @@
 
         api.getContentNegotiation(function(result){
           vm.content_negotiation = result;
-          if (vm.rest.hasOwnProperty('selector')) {
-            for (var i = 0; i < result.length; i++) {
-              if (vm.rest.selector === result[i].content_name) {
-                vm.rest.selector = result[i];
-                break;
-              }
-            }
+          for (var property in result) {
+            vm.selectorNames.push(result[property].content_name);
           }
         });
       });

--- a/src/apigility-ui/rest/rest.html
+++ b/src/apigility-ui/rest/rest.html
@@ -202,7 +202,15 @@
             <div class="form-group">
               <label for="rest_content_negotiation" class="col-sm-2 control-label">Content Negotiation Selector</label>
               <div class="col-sm-8">
-                <select class="form-control" ng-model="vm.rest.selector" ng-options="selector.content_name for selector in vm.content_negotiation" ng-disabled="vm.disabled"></select>
+                <ui-select
+                  ng-model="vm.rest.selector"
+                  ng-disabled="vm.disabled">
+                  <ui-select-match placeholder="Select content negotiation type...">{{$select.selected}}</ui-select-match>
+                  <ui-select-choices
+                    repeat="selector in vm.selectorNames | filter: $select.search">
+                    <div ng-bind-html="selector | highlight: $select.search"></div>
+                  </ui-select-choices>
+                </ui-select>
               </div>
             </div>
             <div class="form-group">

--- a/src/apigility-ui/rpc/rpc.controller.js
+++ b/src/apigility-ui/rpc/rpc.controller.js
@@ -17,6 +17,7 @@
     vm.rpcName = $stateParams.rpc;
     vm.httpMethods = [ 'GET', 'POST', 'PUT', 'PATCH', 'DELETE'];
     vm.disabled = !SidebarService.isLastVersion(vm.version, vm.apiName);
+    vm.selectorNames = [];
 
     function initGeneral() {
       vm.tags = {
@@ -45,11 +46,8 @@
 
         api.getContentNegotiation(function(result){
           vm.content_negotiation = result;
-          for (var i = 0; i < result.length; i++) {
-            if (vm.rpc.selector === result[i].content_name) {
-              vm.rpc.selector = result[i];
-              break;
-            }
+          for (var property in result) {
+            vm.selectorNames.push(result[property].content_name);
           }
         });
       });

--- a/src/apigility-ui/rpc/rpc.html
+++ b/src/apigility-ui/rpc/rpc.html
@@ -38,7 +38,15 @@
           <div class="form-group">
             <label for="rest_content_negotiation" class="col-sm-2 control-label">Content Negotiation Selector</label>
             <div class="col-sm-10">
-              <select class="form-control" ng-model="vm.rpc.selector" ng-options="selector.content_name for selector in vm.content_negotiation" ng-disabled="vm.disabled"></select>
+              <ui-select
+                ng-model="vm.rpc.selector"
+                ng-disabled="vm.disabled">
+                <ui-select-match placeholder="Select content negotiation type...">{{$select.selected}}</ui-select-match>
+                <ui-select-choices
+                  repeat="selector in vm.selectorNames | filter: $select.search">
+                  <div ng-bind-html="selector | highlight: $select.search"></div>
+                </ui-select-choices>
+              </ui-select>
             </div>
           </div>
           <div class="form-group">

--- a/src/apigility-ui/templates.js
+++ b/src/apigility-ui/templates.js
@@ -2067,7 +2067,15 @@ angular.module("apigility-ui/rest/rest.html", []).run(["$templateCache", functio
     "            <div class=\"form-group\">\n" +
     "              <label for=\"rest_content_negotiation\" class=\"col-sm-2 control-label\">Content Negotiation Selector</label>\n" +
     "              <div class=\"col-sm-8\">\n" +
-    "                <select class=\"form-control\" ng-model=\"vm.rest.selector\" ng-options=\"selector.content_name for selector in vm.content_negotiation\" ng-disabled=\"vm.disabled\"></select>\n" +
+    "                <ui-select\n" +
+    "                  ng-model=\"vm.rest.selector\"\n" +
+    "                  ng-disabled=\"vm.disabled\">\n" +
+    "                  <ui-select-match placeholder=\"Select content negotiation type...\">{{$select.selected}}</ui-select-match>\n" +
+    "                  <ui-select-choices\n" +
+    "                    repeat=\"selector in vm.selectorNames | filter: $select.search\">\n" +
+    "                    <div ng-bind-html=\"selector | highlight: $select.search\"></div>\n" +
+    "                  </ui-select-choices>\n" +
+    "                </ui-select>\n" +
     "              </div>\n" +
     "            </div>\n" +
     "            <div class=\"form-group\">\n" +
@@ -2345,7 +2353,15 @@ angular.module("apigility-ui/rpc/rpc.html", []).run(["$templateCache", function(
     "          <div class=\"form-group\">\n" +
     "            <label for=\"rest_content_negotiation\" class=\"col-sm-2 control-label\">Content Negotiation Selector</label>\n" +
     "            <div class=\"col-sm-10\">\n" +
-    "              <select class=\"form-control\" ng-model=\"vm.rpc.selector\" ng-options=\"selector.content_name for selector in vm.content_negotiation\" ng-disabled=\"vm.disabled\"></select>\n" +
+    "              <ui-select\n" +
+    "                ng-model=\"vm.rpc.selector\"\n" +
+    "                ng-disabled=\"vm.disabled\">\n" +
+    "                <ui-select-match placeholder=\"Select content negotiation type...\">{{$select.selected}}</ui-select-match>\n" +
+    "                <ui-select-choices\n" +
+    "                  repeat=\"selector in vm.selectorNames | filter: $select.search\">\n" +
+    "                  <div ng-bind-html=\"selector | highlight: $select.search\"></div>\n" +
+    "                </ui-select-choices>\n" +
+    "              </ui-select>\n" +
     "            </div>\n" +
     "          </div>\n" +
     "          <div class=\"form-group\">\n" +


### PR DESCRIPTION
Fixes zfcampus/zf-apigility-admin#277 by ensuring that only the selector name,
not the entire selector, is sent to the API.

Implements ui-select for the content negotiation selector.