### PR TITLE
#52 Fixed doctrine field names for hydrator strategy

### DIFF
--- a/src/apigility-ui/rest/rest.controller.js
+++ b/src/apigility-ui/rest/rest.controller.js
@@ -136,7 +136,11 @@
         controllerAs: 'vm',
         resolve : {
           fields : function() {
-            return vm.doctrineMetadata.fieldNames;
+            var fields = {};
+            angular.forEach(vm.doctrineMetadata.fieldNames, function (name) {
+              fields[name] = name;
+            });
+            return fields;
           }
         }
       });


### PR DESCRIPTION
```fields``` was populated with the entity column name as key. Fixed to create a key-value pairs with the field name.