### PR TITLE
Corrected route for doctrine service create

### DIFF
--- a/src/apigility-ui/service/api.service.js
+++ b/src/apigility-ui/service/api.service.js
@@ -804,7 +804,7 @@
 
     this.newDoctrine = function(module, adapter, entity, callback) {
       var allowed = [ 'object_manager', 'entity_class', 'service_name' ];
-      xhr.create(agApiPath + '/module/' + module + '/doctrine/' + entity.service_name, [ adapter, entity.entity_class, entity.service_name ], allowed)
+      xhr.create(agApiPath + '/module/' + module + '/doctrine/', [ adapter, entity.entity_class, entity.service_name ], allowed)
         .then(function (response) {
           growl.success('Doctrine-connected service created');
           return callback(false, response);


### PR DESCRIPTION
The documentation for zf-apigility-doctrine was not clear when both comparing the route to a rest route and specifying the create route may contain the service name.  This has been corrected in the documentation and in the function which creates a doctrine resource.

This manifests when adding multiple entities at the same time.

See https://github.com/zfcampus/zf-apigility-doctrine/pull/198