### PR TITLE
Strip error_message when empty

### DIFF
--- a/src/apigility-ui/service/api.service.js
+++ b/src/apigility-ui/service/api.service.js
@@ -166,7 +166,7 @@
     };
 
     this.getAuthorizationRest = function(module, version, name, callback) {
-      xhr.get(agApiPath + '/module/' + module + '/authorization?version=' + version)
+      xhr.get(agApiPath + '/module/' + module + '/authorization')
       .then(function (response) {
         var method;
         var data = {};
@@ -393,6 +393,11 @@
     };
 
     this.saveRestField = function(module, version, restname, fields, callback) {
+      angular.forEach(fields, function (field, key) {
+        if (field.hasOwnProperty('error_message') && ! field.error_message) {
+          delete field.error_message;
+        }
+      });
       xhr.save(agApiPath + '/module/' + module + '/rest/' + module + '-V' + version + '-Rest-' + capitalizeFirstLetter(restname) + '-Controller/input-filter', fields)
       .then(function(response) {
         growl.success('Saved field');
@@ -410,7 +415,7 @@
     };
 
     this.getAuthorizationRpc = function(module, version, name, callback) {
-      xhr.get(agApiPath + '/module/' + module + '/authorization?version=' + version)
+      xhr.get(agApiPath + '/module/' + module + '/authorization')
       .then(function (response) {
         var data = [];
         var controller = response[module + '\\V' + version + '\\Rpc\\' + capitalizeFirstLetter(name) + '\\Controller::' + name];
@@ -446,6 +451,11 @@
     };
 
     this.saveRpcField = function(module, version, rpcname, fields, callback) {
+      angular.forEach(fields, function (field, key) {
+        if (field.hasOwnProperty('error_message') && ! field.error_message) {
+          delete field.error_message;
+        }
+      });
       xhr.save(agApiPath + '/module/' + module + '/rpc/' + module + '-V' + version + '-Rpc-' + capitalizeFirstLetter(rpcname) + '-Controller/input-filter', fields)
       .then(function(response) {
         growl.success('Field saved');
@@ -804,7 +814,7 @@
 
     this.newDoctrine = function(module, adapter, entity, callback) {
       var allowed = [ 'object_manager', 'entity_class', 'service_name' ];
-      xhr.create(agApiPath + '/module/' + module + '/doctrine/', [ adapter, entity.entity_class, entity.service_name ], allowed)
+      xhr.create(agApiPath + '/module/' + module + '/doctrine/' + entity.service_name, [ adapter, entity.entity_class, entity.service_name ], allowed)
         .then(function (response) {
           growl.success('Doctrine-connected service created');
           return callback(false, response);
@@ -916,7 +926,7 @@
           if (err.hasOwnProperty('data') && err.data.hasOwnProperty('detail')) {
             return callback(true, err.data.detail);
           }
-          return callback(true, 'Error creating authentication adapter');
+          return callback(true, 'Error on authentication adapter save');
         });
     };
 
@@ -937,10 +947,7 @@
       })
       .catch(function (err) {
         growl.error('Error updating authentication adapter', {ttl: -1});
-        if (err.hasOwnProperty('data') && err.data.hasOwnProperty('detail')) {
-          return callback(true, err.data.detail);
-        }
-        return callback(true, 'Error updating authentication adapter');
+        return callback(true, 'Error during the authentication adapter API save');
       });
     };
 
@@ -1075,7 +1082,6 @@
 
     function capitalizeFirstLetter(string)
     {
-      string = string.replace(/_(\w)/g, function(_,letter) { return letter.toUpperCase(); });
       return string.charAt(0).toUpperCase() + string.slice(1);
     }
 


### PR DESCRIPTION
If an empty error message is submitted for a field when editing, it should not be sent in the payload to ensure the default validation messages are used.

Fixes zfcampus/zf-content-validation#45