### PR TITLE
Make forwards compatible with ZF v3 releases

### DIFF
--- a/CONDUCT.md
+++ b/CONDUCT.md
@@ -1,0 +1,43 @@
+# Contributor Code of Conduct
+
+The Zend Framework project adheres to [The Code Manifesto](http://codemanifesto.com)
+as its guidelines for contributor interactions.
+
+## The Code Manifesto
+
+We want to work in an ecosystem that empowers developers to reach their
+potential — one that encourages growth and effective collaboration. A space that
+is safe for all.
+
+A space such as this benefits everyone that participates in it. It encourages
+new developers to enter our field. It is through discussion and collaboration
+that we grow, and through growth that we improve.
+
+In the effort to create such a place, we hold to these values:
+
+1. **Discrimination limits us.** This includes discrimination on the basis of
+   race, gender, sexual orientation, gender identity, age, nationality, technology
+   and any other arbitrary exclusion of a group of people.
+2. **Boundaries honor us.** Your comfort levels are not everyone’s comfort
+   levels. Remember that, and if brought to your attention, heed it.
+3. **We are our biggest assets.** None of us were born masters of our trade.
+   Each of us has been helped along the way. Return that favor, when and where
+   you can.
+4. **We are resources for the future.** As an extension of #3, share what you
+   know. Make yourself a resource to help those that come after you.
+5. **Respect defines us.** Treat others as you wish to be treated. Make your
+   discussions, criticisms and debates from a position of respectfulness. Ask
+   yourself, is it true? Is it necessary? Is it constructive? Anything less is
+   unacceptable.
+6. **Reactions require grace.** Angry responses are valid, but abusive language
+   and vindictive actions are toxic. When something happens that offends you,
+   handle it assertively, but be respectful. Escalate reasonably, and try to
+   allow the offender an opportunity to explain themselves, and possibly correct
+   the issue.
+7. **Opinions are just that: opinions.** Each and every one of us, due to our
+   background and upbringing, have varying opinions. The fact of the matter, is
+   that is perfectly acceptable. Remember this: if you respect your own
+   opinions, you should respect the opinions of others.
+8. **To err is human.** You might not intend it, but mistakes do happen and
+   contribute to build experience. Tolerate honest mistakes, and don't hesitate
+   to apologize if you make one yourself.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -13,14 +13,14 @@ Once installed, you may run tests using:
 
 Once dependencies are installed, you may run tests using:
 
-```sh
-grunt test
+```bash
+$ grunt test
 ```
 
 Alternately, fire up a terminal and run:
 
-```sh
-grunt watch
+```bash
+$ grunt watch
 ```
 
 to run tests automatically as files are changed.
@@ -36,7 +36,7 @@ All changes to the admin UI code should be made in the `src/` directory.
 Once you are happy with the changes you have made, you will need to rebuild the
 distribution files. Run the following from this directory:
 
-```console
+```bash
 $ grunt clean && grunt build
 ```
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,56 @@
+# CONTRIBUTING
+
+Apigility and related modules (of which this is one) are open source and licensed
+as [BSD-3-Clause](http://opensource.org/licenses/BSD-3-Clause). Contributions
+are welcome in the form of issue reports and pull requests.
+
+
+## Running Tests
+
+First, please ensure you have [installed all requirements](README.md#requirements).
+
+Once installed, you may run tests using:
+
+Once dependencies are installed, you may run tests using:
+
+```sh
+grunt test
+```
+
+Alternately, fire up a terminal and run:
+
+```sh
+grunt watch
+```
+
+to run tests automatically as files are changed.
+
+## Workflow
+
+To develop the Admin UI (e.g., to add features or fix a bug), you will need to
+run the server using the source, not distribution, files. This means using
+`grunt serve` to develop.
+
+All changes to the admin UI code should be made in the `src/` directory.
+
+Once you are happy with the changes you have made, you will need to rebuild the
+distribution files. Run the following from this directory:
+
+```console
+$ grunt clean && grunt build
+```
+
+Test that everything is working against the distribution on completion.
+
+## Adding JS/CSS Dependencies
+
+If you need to add any new JS or CSS dependencies, please do so as follows:
+
+- Edit the `bower.json` file and add the dependency.
+- Execute `bower install`.
+- Add the files to `src/index.html` in the appropriate section of the file.
+- Commit your changes.
+
+## Conduct
+
+Please see our [CONDUCT.md](CONDUCT.md) to understand expected behavior when interacting with others in the project.

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,0 +1,28 @@
+Copyright (c) 2014-2016, Zend Technologies USA, Inc.
+
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without modification,
+are permitted provided that the following conditions are met:
+
+- Redistributions of source code must retain the above copyright notice,
+  this list of conditions and the following disclaimer.
+
+- Redistributions in binary form must reproduce the above copyright notice,
+  this list of conditions and the following disclaimer in the documentation
+  and/or other materials provided with the distribution.
+
+- Neither the name of Zend Technologies USA, Inc. nor the names of its
+  contributors may be used to endorse or promote products derived from this
+  software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/Module.php
+++ b/Module.php
@@ -1,4 +1,10 @@
 <?php
+/**
+ * @link      http://github.com/zfcampus/zf-apigility-admin-ui for the canonical source repository
+ * @copyright Copyright (c) 2013-2016 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ */
+
 namespace ZF\Apigility\Admin\Ui;
 
 class Module

--- a/README.md
+++ b/README.md
@@ -36,26 +36,26 @@ Requirements
 
 Run the following command from this directory to install dependencies:
 
-```sh
-npm install
+```bash
+$ npm install
 ```
 
 If you have not yet installed Grunt, please do so:
 
-```sh
-sudo npm install -g grunt
+```bash
+$ sudo npm install -g grunt
 ```
 
 If you have not yet installed Bower, please do so:
 
-```sh
-sudo npm install -g bower
+```bash
+$ sudo npm install -g bower
 ```
 
 Finally, invoke Bower to install the relevant CSS and JS libraries:
 
-```sh
-bower install
+```bash
+$ bower install
 ```
 
 Invoking the Admin
@@ -68,7 +68,7 @@ standalone via [node](https://nodejs.org), or via source using grunt.
 
 Add the admin as a dev requirement to your project:
 
-```console
+```bash
 $ composer require-dev "zfcampus/zf-apigility-admin-ui:~1.0"
 ```
 
@@ -92,7 +92,7 @@ navigation item can point to it.
 
 Fire up the admin UI using:
 
-```console
+```bash
 $ node index.js --src --api=<URI to Apigility Admin API (ends in /apigility/api)>
 ```
 
@@ -105,12 +105,15 @@ can specify a port with the `--port=<port>` option.
 
 The `grunt serve` command does several things:
 
-- Runs `grunt watch`, which looks for file changes and runs tasks such as jshint, unit tests, and combining partials into JS templates.
-- Runs a livereload, static HTTP server; any file change will force it to reload, and trigger any browser windows with the UI loaded to reload.
+- Runs `grunt watch`, which looks for file changes and runs tasks such as
+  `jshint`, unit tests, and combining partials into JS templates.
+- Runs a livereload, static HTTP server; any file change will force it to
+  reload, and trigger any browser windows with the UI loaded to reload.
 
-The grunt server runs in the same way as the standalone server: it accepts the same options, and has the same CORS limitations. As an example:
+The grunt server runs in the same way as the standalone server: it accepts the
+same options, and has the same CORS limitations. As an example:
 
-```console
+```bash
 $ grunt serve --api=<URI to Apigility Admin API (ends in /apigility/api)> \
 > --doc=<URI to API documentation> --port=3001 --host=ag.dev
 ```

--- a/README.md
+++ b/README.md
@@ -58,23 +58,6 @@ Finally, invoke Bower to install the relevant CSS and JS libraries:
 bower install
 ```
 
-Running tests
--------------
-
-Once dependencies are installed, you may run tests using:
-
-```sh
-grunt test
-```
-
-Alternately, fire up a terminal and run:
-
-```sh
-grunt watch
-```
-
-to run tests automatically as files are changed.
-
 Invoking the Admin
 ------------------
 
@@ -132,31 +115,5 @@ $ grunt serve --api=<URI to Apigility Admin API (ends in /apigility/api)> \
 > --doc=<URI to API documentation> --port=3001 --host=ag.dev
 ```
 
-Workflow
---------
-
-To develop the Admin UI (e.g., to add features or fix a bug), you will need to
-run the server using the source, not distribution, files. This means using
-`grunt serve` to develop.
-
-All changes to the admin UI code should be made in the `src/` directory.
-
-Once you are happy with the changes you have made, you will need to rebuild the
-distribution files. Run the following from this directory:
-
-```console
-$ grunt clean && grunt build
-```
-
-Test that everything is working against the distribution on completion.
-
-
-Adding JS/CSS Dependencies
---------------------------
-
-If you need to add any new JS or CSS dependencies, please do so as follows:
-
-- Edit the `bower.json` file and add the dependency.
-- Execute `bower install`.
-- Add the files to `src/index.html` in the appropriate section of the file.
-- Commit your changes.
+Please see our [contributing guide](CONTRIBUTING.md) for information on how to
+run tests and hack on the UI.

--- a/composer.json
+++ b/composer.json
@@ -26,12 +26,15 @@
         }
     },
     "require": {
-        "php": ">=5.5",
-        "rwoverdijk/assetmanager": "~1.3",
-        "zendframework/zend-view": "~2.3"
+        "php": "^5.6 || ^7.0",
+        "zendframework/zend-view": "^2.8.1"
     },
     "require-dev": {
-        "zendframework/zend-console": "~2.3"
+        "zendframework/zend-console": "^2.6"
+    },
+    "suggest": {
+        "rwoverdijk/assetmanager": "^1.7, to expose assets under the document root (may not yet be released)",
+        "zfcampus/zf-asset-manager": "^1.0, to expose assets under the document root, until rwoverdijk/assetmanager 1.7 is released"
     },
     "autoload": {
         "classmap": [

--- a/config/module.config.php
+++ b/config/module.config.php
@@ -1,15 +1,21 @@
 <?php
-return array(
-    'asset_manager' => array(
-        'resolver_configs' => array(
-            'paths' => array(
+/**
+ * @link      http://github.com/zfcampus/zf-apigility-admin-ui for the canonical source repository
+ * @copyright Copyright (c) 2013-2016 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ */
+
+return [
+    'asset_manager' => [
+        'resolver_configs' => [
+            'paths' => [
                 __DIR__ . '/../dist/',
-            ),
-        ),
-    ),
-    'view_manager' => array(
-        'template_map' => array(
+            ],
+        ],
+    ],
+    'view_manager' => [
+        'template_map' => [
             'zf-apigility-ui' => __DIR__ . '/../view/zf-apigility-ui.phtml',
-        ),
-    ),
-);
+        ],
+    ],
+];


### PR DESCRIPTION
This one was super-easy:

- Set minimum supported PHP version to 5.6.
- Updated zend-view to ^2.8.1.
- Updated zend-console to ^2.6.
- Removed rwoverdijk/assetmanager:
  - added as a suggestion, but starting at 1.7.
  - also added zfcampus/zf-asset-manager as a suggestion, until rwoverdijk/assetmanager 1.7 is realeased.

Finally, I made a few administrative changes:

- Separated contribution details into CONTRIBUTING.md.
- Added Code Manifesto in CONDUCT.md.
- Added LICENSE.md.
- Added a file-level docblock with license/copyright details to the `Module` class file.

This one has no potential breaking changes whatsoever, thankfully!