### PR TITLE
Fixes display of service name and sidebar refreshing

### DIFF
--- a/src/apigility-ui/api-module/api-module.html
+++ b/src/apigility-ui/api-module/api-module.html
@@ -49,7 +49,7 @@
             <th class="col-sm-6">Description</th>
           </tr>
         </thead>
-        <tr ng-repeat="rest in vm.rest">
+        <tr ng-repeat="rest in vm.rest track by $index">
           <td><a ui-sref="ag.rest({api: vm.apiName, ver: vm.version, rest: rest.controller_service_name})" ng-click="vm.setSelected('api'+vm.apiName+'rest'+rest.service_name)">{{rest.service_name}}</a></td>
           <td>{{rest.route_match}}</td>
           <td>
@@ -74,7 +74,7 @@
             <th class="col-sm-6">Description</th>
           </tr>
         </thead>
-        <tr ng-repeat="rpc in vm.rpc">
+        <tr ng-repeat="rpc in vm.rpc track by $index">
           <td><a ui-sref="ag.rpc({api: vm.apiName, ver: vm.version, rpc: rpc.controller_service_name})" ng-click="vm.setSelected('api'+vm.apiName+'rpc'+rpc.service_name)">{{rpc.service_name}}</a></td>
           <td>{{rpc.route_match}}</td>
           <td>

--- a/src/apigility-ui/modal/delete-rpc.controller.js
+++ b/src/apigility-ui/modal/delete-rpc.controller.js
@@ -18,19 +18,23 @@
 
     vm.cancel = $modalInstance.dismiss;
 
-    vm.ok = function() {
+    vm.ok = function () {
       vm.loading = true;
-      api.deleteRpc(vm.apiName, vm.version, vm.rpcName, vm.recursive, function(err, response) {
+      api.deleteRpc(vm.apiName, vm.version, vm.rpcName, vm.recursive, function (err, response) {
         if (err) {
           vm.alert = 'Error during the delete of the service';
           vm.loading = false;
           return;
         }
-        $timeout(function(){
+        $timeout(function () {
           vm.loading = false;
-          $modalInstance.close(vm.apiName, vm.version, vm.rpcName);
+          $modalInstance.close({
+            'api': vm.apiName,
+            'version': vm.version,
+            'service': vm.rpcName
+          });
         }, 2000);
       });
-    }
+    };
   }
 })();

--- a/src/apigility-ui/rest/rest.controller.js
+++ b/src/apigility-ui/rest/rest.controller.js
@@ -44,6 +44,7 @@
 
       api.getRest(vm.apiName, vm.version, vm.restName, function(result){
         vm.rest = result;
+        vm.serviceName = vm.rest.service_name;
         vm.isDoctrine = angular.isDefined(result.object_manager);
 
         vm.rest.accept_whitelist.forEach(function(entry){

--- a/src/apigility-ui/rest/rest.html
+++ b/src/apigility-ui/rest/rest.html
@@ -2,7 +2,7 @@
   <div class="panel-heading">
     <h3 class="panel-title">
       <span class="service-button pull-right"><button class="btn btn-danger" ng-click="vm.deleteRestModal()" ng-hide="vm.disabled"><span class="glyphicon glyphicon-trash"></span> Delete service</button></span>
-      <span class="glyphicon glyphicon-leaf"></span> REST service: {{vm.restName}} (v{{vm.version}})
+      <span class="glyphicon glyphicon-leaf"></span> REST service: {{vm.serviceName}} (v{{vm.version}})
     </h3>
   </div>
   <div class="panel-body">

--- a/src/apigility-ui/rpc/rpc.controller.js
+++ b/src/apigility-ui/rpc/rpc.controller.js
@@ -31,6 +31,7 @@
           return;
         }
         vm.rpc = result;
+        vm.serviceName = vm.rpc.service_name;
         vm.rpc.accept_whitelist.forEach(function(entry){
           vm.tags.accept_whitelist.push({ text : entry });
         });

--- a/src/apigility-ui/rpc/rpc.controller.js
+++ b/src/apigility-ui/rpc/rpc.controller.js
@@ -122,9 +122,9 @@
         controllerAs: 'vm'
       });
 
-      modalInstance.result.then(function (api, version, service) {
-        SidebarService.removeRpcService(api, service);
-        $state.go('ag.apimodule', {api: api, ver: version}, {reload: true});
+      modalInstance.result.then(function (response) {
+        SidebarService.removeRpcService(response.api, response.service);
+        $state.go('ag.apimodule', {api: response.api, ver: response.version}, {reload: true});
       });
     };
 

--- a/src/apigility-ui/rpc/rpc.html
+++ b/src/apigility-ui/rpc/rpc.html
@@ -2,7 +2,7 @@
   <div class="panel-heading">
     <h3 class="panel-title">
       <span class="service-button pull-right"><button class="btn btn-danger" ng-click="vm.deleteRpcModal()" ng-hide="vm.disabled"><span class="glyphicon glyphicon-trash"></span> Delete service</button></span>
-      <span class="glyphicon glyphicon-fire"></span> RPC service: {{vm.rpcName}} (v{{vm.version}})
+      <span class="glyphicon glyphicon-fire"></span> RPC service: {{vm.serviceName}} (v{{vm.version}})
     </h3>
   </div>
   <div class="panel-body">

--- a/src/apigility-ui/service/sidebar.service.js
+++ b/src/apigility-ui/service/sidebar.service.js
@@ -21,24 +21,25 @@
     };
 
     var setSelectedVersion = function(apiName, version) {
-      for(var i = 0; i < apis.length; i++) {
-        if (apis[i].name === apiName) {
-          apis[i].selected_version = version;
-          api.getRestList(apiName, version, function(result){
-            apis[i].rest = [];
-            result.forEach(function(entry){
-              apis[i].rest.push(entry.service_name);
-            });
-          });
-          api.getRpcList(apiName, version, function(result){
-            apis[i].rpc = [];
-            result.forEach(function(entry){
-              apis[i].rpc.push(entry.service_name);
-            });
-          });
+      apis.forEach(function (currentApi) {
+        if (currentApi.name !== apiName) {
           return;
         }
-      }
+
+        api.getRestList(apiName, version, function (restResult) {
+          currentApi.rest = [];
+          restResult.forEach(function (entry) {
+            currentApi.rest.push(entry);
+          });
+        });
+
+        api.getRpcList(apiName, version, function (rpcResult) {
+          currentApi.rpc = [];
+          rpcResult.forEach(function (entry) {
+            currentApi.rpc.push(entry);
+          });
+        });
+      });
     };
 
     var getSelectedVersion = function(apiName){
@@ -80,7 +81,7 @@
 
     var getApis = function(){
       return apis;
-    }
+    };
 
     var addRestService = function(apiName, serviceName){
       apis.forEach(function(api){
@@ -98,7 +99,7 @@
           api.rest.splice(api.rest.indexOf(serviceName),1);
         }
         newApis.push(api);
-      })
+      });
       apis = newApis;
     };
 
@@ -109,7 +110,7 @@
           api.rpc.splice(api.rpc.indexOf(serviceName),1);
         }
         newApis.push(api);
-      })
+      });
       apis = newApis;
     };
 
@@ -120,15 +121,15 @@
           return;
         }
       });
-    }
+    };
 
     var getSelected = function(){
       return selected;
-    }
+    };
 
     var setSelected = function(data){
       selected = data;
-    }
+    };
 
     return {
       addVersion : addVersion,

--- a/src/apigility-ui/service/sidebar.service.js
+++ b/src/apigility-ui/service/sidebar.service.js
@@ -92,25 +92,69 @@
       });
     };
 
-    var removeRestService = function(apiName, serviceName){
+    var removeRestService = function(apiName, serviceName) {
       var newApis = [];
-      apis.forEach(function(api){
-        if (api.name == apiName) {
-          api.rest.splice(api.rest.indexOf(serviceName),1);
+      var apiToUpdate;
+      var toRemove;
+
+      apis.forEach(function (api) {
+        if (api.name !== apiName) {
+          newApis.push(api);
+          return;
         }
-        newApis.push(api);
+
+        toRemove = false;
+        api.rest.forEach(function (service, index) {
+          if (service.controller_service_name !== serviceName) {
+            return;
+          }
+
+          toRemove = index;
+        });
+
+        if (false === toRemove) {
+          newApis.push(api);
+          return;
+        }
+
+        apiToUpdate = angular.copy(api);
+        apiToUpdate.rest.splice(toRemove, 1);
+        newApis.push(apiToUpdate);
       });
+
       apis = newApis;
     };
 
-    var removeRpcService = function(apiName, serviceName){
+    var removeRpcService = function(apiName, serviceName) {
       var newApis = [];
-      apis.forEach(function(api){
-        if (api.name == apiName) {
-          api.rpc.splice(api.rpc.indexOf(serviceName),1);
+      var apiToUpdate;
+      var toRemove;
+
+      apis.forEach(function (api) {
+        if (api.name !== apiName) {
+          newApis.push(api);
+          return;
         }
-        newApis.push(api);
+
+        toRemove = false;
+        api.rpc.forEach(function (service, index) {
+          if (service.controller_service_name !== serviceName) {
+            return;
+          }
+
+          toRemove = index;
+        });
+
+        if (false === toRemove) {
+          newApis.push(api);
+          return;
+        }
+
+        apiToUpdate = angular.copy(api);
+        apiToUpdate.rpc.splice(toRemove, 1);
+        newApis.push(apiToUpdate);
       });
+
       apis = newApis;
     };
 

--- a/src/apigility-ui/sidebar/sidebar.controller.js
+++ b/src/apigility-ui/sidebar/sidebar.controller.js
@@ -90,18 +90,13 @@
         if (response.hasOwnProperty('rest')) {
           SidebarService.setSelectedVersion(response.api, response.ver);
           $state.go('ag.rest', {api: response.api, ver: response.ver, rest: response.rest});
-          SidebarService.addRestService(response.api, response.rest);
           vm.setSelected('api' + response.api + 'rest' + response.rest);
         } else if (response.hasOwnProperty('rpc')) {
           SidebarService.setSelectedVersion(response.api, response.ver);
           $state.go('ag.rpc', {api: response.api, ver: response.ver, rpc: response.rpc});
-          SidebarService.addRpcService(response.api, response.rpc);
           vm.setSelected('api' + response.api + 'rpc' + response.rpc);
         } else if (response.hasOwnProperty('rests')) {
           SidebarService.setSelectedVersion(response.api, response.ver);
-          response.rests.forEach(function(service) {
-            SidebarService.addRestService(response.api, service);
-          });
           $state.go('ag.apimodule', {api: response.api, ver: response.ver});
         }
       });

--- a/src/apigility-ui/sidebar/sidebar.html
+++ b/src/apigility-ui/sidebar/sidebar.html
@@ -30,7 +30,7 @@
 
 <div class="api-tree" ui-tree class="ng-scope angular-ui-tree" data-drag-enabled="false" data-max-depth="2" ng-hide="vm.apis.length == 0">
   <ol ui-tree-nodes="options" ng-model="vm.apis" class="ng-scope ng-pristine ng-valid angular-ui-tree-nodes">
-    <li class="ng-scope angular-ui-tree-node" ng-repeat="item in vm.apis" ui-tree-node="">
+    <li class="ng-scope angular-ui-tree-node" ng-repeat="item in vm.apis track by $index" ui-tree-node="">
       <div class="ng-scope ng-binding angular-ui-tree-handle" ui-tree-handle ng-class="{ 'selected' : 'api'+item.name === vm.getSelected() }">
         <a class="btn btn-default btn-xs" ng-click="vm.toggle(this)" data-nodrag="">
           <span ng-class="{'glyphicon-chevron-right': collapsed, 'glyphicon-chevron-down': !collapsed}" class="glyphicon glyphicon-chevron-down"></span>
@@ -39,12 +39,12 @@
         <span class="badge pull-right">{{item.rest.length + item.rpc.length}}</span>
       </div>
       <ol class="ng-scope ng-pristine ng-valid angular-ui-tree-nodes" ng-class="{hidden: collapsed}">
-        <li class="ng-scope angular-ui-tree-node" ng-repeat="subItem in item.rest">
+        <li class="ng-scope angular-ui-tree-node" ng-repeat="subItem in item.rest track by $index">
           <div class="ng-scope ng-binding angular-ui-tree-handle" ui-tree-handle ng-class="{ 'selected' : 'api'+item.name+'rest'+subItem.service_name === vm.getSelected() }">
             <span class="glyphicon glyphicon-leaf"></span> <a ui-sref="ag.rest({api: item.name, ver: item.selected_version, rest: subItem.controller_service_name})" ng-click="vm.setSelected('api'+item.name+'rest'+subItem.service_name)">{{subItem.service_name}}</a>
           </div>
         </li>
-        <li class="ng-scope angular-ui-tree-node" ng-repeat="subItem in item.rpc">
+        <li class="ng-scope angular-ui-tree-node" ng-repeat="subItem in item.rpc track by $index">
           <div class="ng-scope ng-binding angular-ui-tree-handle" ui-tree-handle ng-class="{ 'selected' : 'api'+item.name+'rpc'+subItem.service_name === vm.getSelected() }">
             <span class="glyphicon glyphicon-fire"></span> <a ui-sref="ag.rpc({api: item.name, ver: item.selected_version, rpc: subItem.controller_service_name})" ng-click="vm.setSelected('api'+item.name+'rpc'+subItem.service_name)">{{subItem.service_name}}</a>
           </div>

--- a/src/apigility-ui/templates.js
+++ b/src/apigility-ui/templates.js
@@ -1889,7 +1889,7 @@ angular.module("apigility-ui/rest/rest.html", []).run(["$templateCache", functio
     "  <div class=\"panel-heading\">\n" +
     "    <h3 class=\"panel-title\">\n" +
     "      <span class=\"service-button pull-right\"><button class=\"btn btn-danger\" ng-click=\"vm.deleteRestModal()\" ng-hide=\"vm.disabled\"><span class=\"glyphicon glyphicon-trash\"></span> Delete service</button></span>\n" +
-    "      <span class=\"glyphicon glyphicon-leaf\"></span> REST service: {{vm.restName}} (v{{vm.version}})\n" +
+    "      <span class=\"glyphicon glyphicon-leaf\"></span> REST service: {{vm.serviceName}} (v{{vm.version}})\n" +
     "    </h3>\n" +
     "  </div>\n" +
     "  <div class=\"panel-body\">\n" +
@@ -2347,7 +2347,7 @@ angular.module("apigility-ui/rpc/rpc.html", []).run(["$templateCache", function(
     "  <div class=\"panel-heading\">\n" +
     "    <h3 class=\"panel-title\">\n" +
     "      <span class=\"service-button pull-right\"><button class=\"btn btn-danger\" ng-click=\"vm.deleteRpcModal()\" ng-hide=\"vm.disabled\"><span class=\"glyphicon glyphicon-trash\"></span> Delete service</button></span>\n" +
-    "      <span class=\"glyphicon glyphicon-fire\"></span> RPC service: {{vm.rpcName}} (v{{vm.version}})\n" +
+    "      <span class=\"glyphicon glyphicon-fire\"></span> RPC service: {{vm.serviceName}} (v{{vm.version}})\n" +
     "    </h3>\n" +
     "  </div>\n" +
     "  <div class=\"panel-body\">\n" +

--- a/src/apigility-ui/templates.js
+++ b/src/apigility-ui/templates.js
@@ -73,7 +73,7 @@ angular.module("apigility-ui/api-module/api-module.html", []).run(["$templateCac
     "            <th class=\"col-sm-6\">Description</th>\n" +
     "          </tr>\n" +
     "        </thead>\n" +
-    "        <tr ng-repeat=\"rest in vm.rest\">\n" +
+    "        <tr ng-repeat=\"rest in vm.rest track by $index\">\n" +
     "          <td><a ui-sref=\"ag.rest({api: vm.apiName, ver: vm.version, rest: rest.controller_service_name})\" ng-click=\"vm.setSelected('api'+vm.apiName+'rest'+rest.service_name)\">{{rest.service_name}}</a></td>\n" +
     "          <td>{{rest.route_match}}</td>\n" +
     "          <td>\n" +
@@ -98,7 +98,7 @@ angular.module("apigility-ui/api-module/api-module.html", []).run(["$templateCac
     "            <th class=\"col-sm-6\">Description</th>\n" +
     "          </tr>\n" +
     "        </thead>\n" +
-    "        <tr ng-repeat=\"rpc in vm.rpc\">\n" +
+    "        <tr ng-repeat=\"rpc in vm.rpc track by $index\">\n" +
     "          <td><a ui-sref=\"ag.rpc({api: vm.apiName, ver: vm.version, rpc: rpc.controller_service_name})\" ng-click=\"vm.setSelected('api'+vm.apiName+'rpc'+rpc.service_name)\">{{rpc.service_name}}</a></td>\n" +
     "          <td>{{rpc.route_match}}</td>\n" +
     "          <td>\n" +
@@ -2595,7 +2595,7 @@ angular.module("apigility-ui/sidebar/sidebar.html", []).run(["$templateCache", f
     "\n" +
     "<div class=\"api-tree\" ui-tree class=\"ng-scope angular-ui-tree\" data-drag-enabled=\"false\" data-max-depth=\"2\" ng-hide=\"vm.apis.length == 0\">\n" +
     "  <ol ui-tree-nodes=\"options\" ng-model=\"vm.apis\" class=\"ng-scope ng-pristine ng-valid angular-ui-tree-nodes\">\n" +
-    "    <li class=\"ng-scope angular-ui-tree-node\" ng-repeat=\"item in vm.apis\" ui-tree-node=\"\">\n" +
+    "    <li class=\"ng-scope angular-ui-tree-node\" ng-repeat=\"item in vm.apis track by $index\" ui-tree-node=\"\">\n" +
     "      <div class=\"ng-scope ng-binding angular-ui-tree-handle\" ui-tree-handle ng-class=\"{ 'selected' : 'api'+item.name === vm.getSelected() }\">\n" +
     "        <a class=\"btn btn-default btn-xs\" ng-click=\"vm.toggle(this)\" data-nodrag=\"\">\n" +
     "          <span ng-class=\"{'glyphicon-chevron-right': collapsed, 'glyphicon-chevron-down': !collapsed}\" class=\"glyphicon glyphicon-chevron-down\"></span>\n" +
@@ -2604,12 +2604,12 @@ angular.module("apigility-ui/sidebar/sidebar.html", []).run(["$templateCache", f
     "        <span class=\"badge pull-right\">{{item.rest.length + item.rpc.length}}</span>\n" +
     "      </div>\n" +
     "      <ol class=\"ng-scope ng-pristine ng-valid angular-ui-tree-nodes\" ng-class=\"{hidden: collapsed}\">\n" +
-    "        <li class=\"ng-scope angular-ui-tree-node\" ng-repeat=\"subItem in item.rest\">\n" +
+    "        <li class=\"ng-scope angular-ui-tree-node\" ng-repeat=\"subItem in item.rest track by $index\">\n" +
     "          <div class=\"ng-scope ng-binding angular-ui-tree-handle\" ui-tree-handle ng-class=\"{ 'selected' : 'api'+item.name+'rest'+subItem.service_name === vm.getSelected() }\">\n" +
     "            <span class=\"glyphicon glyphicon-leaf\"></span> <a ui-sref=\"ag.rest({api: item.name, ver: item.selected_version, rest: subItem.controller_service_name})\" ng-click=\"vm.setSelected('api'+item.name+'rest'+subItem.service_name)\">{{subItem.service_name}}</a>\n" +
     "          </div>\n" +
     "        </li>\n" +
-    "        <li class=\"ng-scope angular-ui-tree-node\" ng-repeat=\"subItem in item.rpc\">\n" +
+    "        <li class=\"ng-scope angular-ui-tree-node\" ng-repeat=\"subItem in item.rpc track by $index\">\n" +
     "          <div class=\"ng-scope ng-binding angular-ui-tree-handle\" ui-tree-handle ng-class=\"{ 'selected' : 'api'+item.name+'rpc'+subItem.service_name === vm.getSelected() }\">\n" +
     "            <span class=\"glyphicon glyphicon-fire\"></span> <a ui-sref=\"ag.rpc({api: item.name, ver: item.selected_version, rpc: subItem.controller_service_name})\" ng-click=\"vm.setSelected('api'+item.name+'rpc'+subItem.service_name)\">{{subItem.service_name}}</a>\n" +
     "          </div>\n" +


### PR DESCRIPTION
This patch does the following:

- Updates the service landing pages to use the short service_name instead of the controller_service_name in their titles.
- Fixes how the sidebar updates when a new service is added. Prior to this patch, the service name would go AWOL, though a placeholder item would be present for it.
- Fixes how the sidebar updates when a service is removed. Prior to this patch, the last service of the given type would be removed; now the appropriate service entry is removed.