### PR TITLE
Fetch apigility version via API, if possible

### DIFF
--- a/src/apigility-ui/about/about.controller.js
+++ b/src/apigility-ui/about/about.controller.js
@@ -12,6 +12,14 @@
     /* jshint validthis:true */
     var vm = this;
 
-    vm.version = '1.3.2';
+    vm.version = '@dev';
+
+    function init() {
+      api.getApigilityVersion(function (data) {
+        vm.version = data.version;
+      });
+    }
+
+    init();
   }
 })();

--- a/src/apigility-ui/service/api.service.js
+++ b/src/apigility-ui/service/api.service.js
@@ -19,12 +19,12 @@
       xhr.get(agApiPath + '/apigility-version')
         .then(function (response) {
           if (typeof response.version !== 'string') {
-            return callback(false, { version: '@dev' });
+            return callback({ version: '@dev' });
           }
-          return callback(false, response);
+          return callback(response);
         })
         .catch(function (err) {
-          return callback(false, { version: '@dev' });
+          return callback({ version: '@dev' });
         });
     };
 

--- a/src/apigility-ui/service/api.service.js
+++ b/src/apigility-ui/service/api.service.js
@@ -15,6 +15,19 @@
 
     var httpMethods = [ 'GET', 'POST', 'PUT', 'PATCH', 'DELETE'];
 
+    this.getApigilityVersion = function (callback) {
+      xhr.get(agApiPath + '/apigility-version')
+        .then(function (response) {
+          if (typeof response.version !== 'string') {
+            return callback(false, { version: '@dev' });
+          }
+          return callback(false, response);
+        })
+        .catch(function (err) {
+          return callback(false, { version: '@dev' });
+        });
+    };
+
     this.getApiList = function(callback) {
       xhr.get(agApiPath + '/dashboard', '_embedded')
         .then(function (response) {


### PR DESCRIPTION
- On initialization of about screen, trigger an API call to retrieve the apigility version.
  - If an XHR error occurs, use the value `@dev`
  - If the returned payload does not include the `version` key and/or it is not a string, use the value `@dev`
  - Otherwise, use the version retrieved.
- Initialize to `@dev` until the API call is complete.