### PR TITLE
Fixes new service modal handler in API dashboard

### DIFF
--- a/src/apigility-ui/api-module/api-module.controller.js
+++ b/src/apigility-ui/api-module/api-module.controller.js
@@ -92,7 +92,18 @@
       });
 
       modalInstance.result.then(function (response) {
-        SidebarService.addRestService(response.api, response.rest);
+        if (response.hasOwnProperty('rest')) {
+          SidebarService.setSelectedVersion(response.api, response.ver);
+          $state.go('ag.rest', {api: response.api, ver: response.ver, rest: response.rest});
+          vm.setSelected('api' + response.api + 'rest' + response.rest);
+        } else if (response.hasOwnProperty('rpc')) {
+          SidebarService.setSelectedVersion(response.api, response.ver);
+          $state.go('ag.rpc', {api: response.api, ver: response.ver, rpc: response.rpc});
+          vm.setSelected('api' + response.api + 'rpc' + response.rpc);
+        } else if (response.hasOwnProperty('rests')) {
+          SidebarService.setSelectedVersion(response.api, response.ver);
+          $state.go('ag.apimodule', {api: response.api, ver: response.ver});
+        }
       });
     };
 
@@ -104,7 +115,7 @@
           vm.alert = response;
           return;
         }
-      })
+      });
     };
 
     vm.saveAuthentication = function(auth) {


### PR DESCRIPTION
As reported by @webimpress, when creating a new REST or RPC service using the links inside the API dashboard ("No (REST|RPC) services, create a new one"), the sidebar was not updated.

This patch syncs the modal response listener from the sidebar controller to the api-module controller.