### PR TITLE
Fixes transition to new API version

### DIFF
--- a/src/apigility-ui/sidebar/sidebar.controller.js
+++ b/src/apigility-ui/sidebar/sidebar.controller.js
@@ -15,7 +15,6 @@
     vm.apis = SidebarService.getApis();
     vm.getSelected = SidebarService.getSelected;
     vm.setSelected = SidebarService.setSelected;
-    vm.changeVersion = SidebarService.setSelectedVersion;
     vm.search = '';
 
     // Make an API call if the list of APIs is empty
@@ -100,6 +99,11 @@
           $state.go('ag.apimodule', {api: response.api, ver: response.ver});
         }
       });
+    };
+
+    vm.changeVersion = function (apiName, apiVersion) {
+      SidebarService.setSelectedVersion(apiName, apiVersion);
+      $state.go('ag.apimodule', {api: apiName, ver: apiVersion});
     };
 
     function getServiceList(apiClient, apiList) {


### PR DESCRIPTION
Prior to this patch, selecting an API version using the dropdown next to the API would update the sidebar, but not transition to the API dashboard for that version.

This patch updates the logic to do so, by issuing a ui-router state transition after the sidebar is updated.