### PR TITLE
Sidebar should use selected version, not default version

### DIFF
--- a/src/apigility-ui/sidebar/sidebar.controller.js
+++ b/src/apigility-ui/sidebar/sidebar.controller.js
@@ -112,13 +112,13 @@
         api.rest.forEach(function(service){
           vm.services.push(service);
         });
-        apiClient.getRestList(api.name, api.default_version, function(restList) {
+        apiClient.getRestList(api.name, api.selected_version, function(restList) {
           api.rest = restList;
         });
         api.rpc.forEach(function(service){
           vm.services.push(service);
         });
-        apiClient.getRpcList(api.name, api.default_version, function(rpcList) {
+        apiClient.getRpcList(api.name, api.selected_version, function(rpcList) {
           api.rpc = rpcList;
         });
       });


### PR DESCRIPTION
Per #122, the sidebar, on initial load, should be using the API's selected version on initial load, not the default version, when retrieving and displaying services.

Fixes #122.