### PR TITLE
Implemented "Add a description for this service" modal

### DIFF
--- a/src/apigility-ui/api-module/api-module.controller.js
+++ b/src/apigility-ui/api-module/api-module.controller.js
@@ -107,6 +107,26 @@
       });
     };
 
+    vm.addServiceDescriptionModal = function (service, type) {
+      var modalInstance = $modal.open({
+        templateUrl: 'apigility-ui/modal/add-service-description.html',
+        controller: 'AddServiceDescription',
+        controllerAs: 'vm',
+        resolve: {
+          service: function () {
+            return service;
+          },
+          type: function () {
+            return type;
+          }
+        }
+      });
+
+      modalInstance.result.then(function (response) {
+        $state.reload();
+      });
+    };
+
     vm.setDefaultVersion = function() {
       vm.loading = true;
       api.setDefaultVersion(vm.apiName, vm.module.default_version, function(err, response){

--- a/src/apigility-ui/api-module/api-module.html
+++ b/src/apigility-ui/api-module/api-module.html
@@ -53,7 +53,7 @@
           <td><a ui-sref="ag.rest({api: vm.apiName, ver: vm.version, rest: rest.controller_service_name})" ng-click="vm.setSelected('api'+vm.apiName+'rest'+rest.service_name)">{{rest.service_name}}</a></td>
           <td>{{rest.route_match}}</td>
           <td>
-            <a href="" ng-if="!rest._embedded.documentation.description" ng-hide="vm.disabled">Add a description for this service</a>
+            <a ng-click="vm.addServiceDescriptionModal(rest, 'rest')" ng-if="!rest._embedded.documentation.description" ng-hide="vm.disabled">Add a description for this service</a>
             <span ng-if="rest._embedded.documentation.description">{{rest._embedded.documentation.description}}</span>
           </td>
         </tr>
@@ -78,7 +78,7 @@
           <td><a ui-sref="ag.rpc({api: vm.apiName, ver: vm.version, rpc: rpc.controller_service_name})" ng-click="vm.setSelected('api'+vm.apiName+'rpc'+rpc.service_name)">{{rpc.service_name}}</a></td>
           <td>{{rpc.route_match}}</td>
           <td>
-            <a href="" ng-if="!rpc._embedded.documentation.description" ng-hide="vm.disabled">Add a description for this service</a>
+            <a ng-click="vm.addServiceDescriptionModal(rpc, 'rpc')" ng-if="!rpc._embedded.documentation.description" ng-hide="vm.disabled">Add a description for this service</a>
             <span ng-if="rpc._embedded.documentation.description">{{rpc._embedded.documentation.description}}</span>
           </td>
         </tr>

--- a/src/apigility-ui/modal/add-service-description.controller.js
+++ b/src/apigility-ui/modal/add-service-description.controller.js
@@ -1,0 +1,55 @@
+/* jshint latedef: false */
+(function () {
+  'use strict';
+
+  angular
+  .module('apigility.modal')
+  .controller('AddServiceDescription', AddServiceDescription);
+
+  AddServiceDescription.$inject = [ '$modalInstance', '$stateParams', 'api', 'service', 'type' ];
+
+  function AddServiceDescription($modalInstance, $stateParams, api, service, type) {
+    /* jshint validthis:true */
+    var vm = this;
+    var apiName = $stateParams.api;
+    var version = $stateParams.ver;
+
+    vm.service_name = service.service_name;
+    vm.description = '';
+    vm.loading = false;
+    vm.cancel = $modalInstance.dismiss;
+
+    vm.ok = function() {
+      if (!vm.description) {
+        vm.alert = 'The option name cannot be empty';
+        return;
+      }
+      vm.loading = true;
+
+      var documentation;
+      if (typeof service._embedded !== 'object' || typeof service._embedded.documentation !== 'object') {
+        documentation = {description: vm.description};
+      } else {
+        documentation = angular.copy(service._embedded.documentation);
+        documentation.description = vm.description;
+      }
+
+      if (type === 'rest') {
+        api.saveRestDoc(apiName, version, service.controller_service_name, documentation, refreshModuleDashboard);
+      } else if (type === 'rpc') {
+        api.saveRpcDoc(apiName, version, service.controller_service_name, documentation, refreshModuleDashboard);
+      }
+    };
+
+    function refreshModuleDashboard(err, response) {
+      vm.loading = false;
+
+      if (err) {
+        vm.alert = response;
+        return;
+      }
+
+      $modalInstance.close({api: apiName, ver: version});
+    }
+  }
+})();

--- a/src/apigility-ui/modal/add-service-description.html
+++ b/src/apigility-ui/modal/add-service-description.html
@@ -1,0 +1,17 @@
+<div class="modal-header">
+  <h4 class="modal-title">Add service description for <strong>{{vm.service_name}}</strong></h4>
+</div>
+
+<div class="modal-body">
+  <label class="control-label">Description</label>
+  <input class="form-control" type="text" ng-model="vm.description" placeholder="Insert the service description" autofocus />
+</div>
+
+<div class="modal-footer">
+  <div class="alert alert-danger" role="alert" ng-hide="!vm.alert">
+    <span class="glyphicon glyphicon-exclamation-sign" aria-hidden="true"></span> {{vm.alert}}
+  </div>
+
+  <button class="btn btn-default" type="button" ng-click="vm.cancel()">Close</button>
+  <button class="btn btn-success" type="button" ng-click="vm.ok()" ladda="vm.loading">Save</button>
+</div>

--- a/src/apigility-ui/templates.js
+++ b/src/apigility-ui/templates.js
@@ -1,4 +1,4 @@
-angular.module('templates-main', ['apigility-ui/about/about.html', 'apigility-ui/api-module/api-module.html', 'apigility-ui/authentication/authentication.html', 'apigility-ui/content-negotiation/content-negotiation.html', 'apigility-ui/dashboard/dashboard.html', 'apigility-ui/database/database.html', 'apigility-ui/documentation/documentation-api.html', 'apigility-ui/documentation/documentation-list.html', 'apigility-ui/documentation/documentation-service.html', 'apigility-ui/documentation/documentation.html', 'apigility-ui/header/header.html', 'apigility-ui/modal/add-authoption.html', 'apigility-ui/modal/add-dboption.html', 'apigility-ui/modal/add-filter.html', 'apigility-ui/modal/add-validator.html', 'apigility-ui/modal/delete-api.html', 'apigility-ui/modal/delete-auth.html', 'apigility-ui/modal/delete-authoption.html', 'apigility-ui/modal/delete-db.html', 'apigility-ui/modal/delete-dboption.html', 'apigility-ui/modal/delete-field.html', 'apigility-ui/modal/delete-filter.html', 'apigility-ui/modal/delete-rest.html', 'apigility-ui/modal/delete-rpc.html', 'apigility-ui/modal/delete-selector.html', 'apigility-ui/modal/delete-validator.html', 'apigility-ui/modal/delete-viewmodel.html', 'apigility-ui/modal/edit-auth.html', 'apigility-ui/modal/edit-authoption.html', 'apigility-ui/modal/edit-db.html', 'apigility-ui/modal/edit-dboption.html', 'apigility-ui/modal/edit-field.html', 'apigility-ui/modal/edit-filter.html', 'apigility-ui/modal/edit-validator.html', 'apigility-ui/modal/edit-viewmodel.html', 'apigility-ui/modal/new-api.html', 'apigility-ui/modal/new-auth.html', 'apigility-ui/modal/new-db.html', 'apigility-ui/modal/new-doctrinestrategy.html', 'apigility-ui/modal/new-field.html', 'apigility-ui/modal/new-selector.html', 'apigility-ui/modal/new-service.html', 'apigility-ui/modal/new-version.html', 'apigility-ui/modal/new-viewmodel.html', 'apigility-ui/modal/view-doctrineparams.html', 'apigility-ui/package/package.html', 'apigility-ui/rest/rest.html', 'apigility-ui/rpc/rpc.html', 'apigility-ui/sidebar/sidebar.html']);
+angular.module('templates-main', ['apigility-ui/about/about.html', 'apigility-ui/api-module/api-module.html', 'apigility-ui/authentication/authentication.html', 'apigility-ui/content-negotiation/content-negotiation.html', 'apigility-ui/dashboard/dashboard.html', 'apigility-ui/database/database.html', 'apigility-ui/documentation/documentation-api.html', 'apigility-ui/documentation/documentation-list.html', 'apigility-ui/documentation/documentation-service.html', 'apigility-ui/documentation/documentation.html', 'apigility-ui/header/header.html', 'apigility-ui/modal/add-authoption.html', 'apigility-ui/modal/add-dboption.html', 'apigility-ui/modal/add-filter.html', 'apigility-ui/modal/add-service-description.html', 'apigility-ui/modal/add-validator.html', 'apigility-ui/modal/delete-api.html', 'apigility-ui/modal/delete-auth.html', 'apigility-ui/modal/delete-authoption.html', 'apigility-ui/modal/delete-db.html', 'apigility-ui/modal/delete-dboption.html', 'apigility-ui/modal/delete-field.html', 'apigility-ui/modal/delete-filter.html', 'apigility-ui/modal/delete-rest.html', 'apigility-ui/modal/delete-rpc.html', 'apigility-ui/modal/delete-selector.html', 'apigility-ui/modal/delete-validator.html', 'apigility-ui/modal/delete-viewmodel.html', 'apigility-ui/modal/edit-auth.html', 'apigility-ui/modal/edit-authoption.html', 'apigility-ui/modal/edit-db.html', 'apigility-ui/modal/edit-dboption.html', 'apigility-ui/modal/edit-field.html', 'apigility-ui/modal/edit-filter.html', 'apigility-ui/modal/edit-validator.html', 'apigility-ui/modal/edit-viewmodel.html', 'apigility-ui/modal/new-api.html', 'apigility-ui/modal/new-auth.html', 'apigility-ui/modal/new-db.html', 'apigility-ui/modal/new-doctrinestrategy.html', 'apigility-ui/modal/new-field.html', 'apigility-ui/modal/new-selector.html', 'apigility-ui/modal/new-service.html', 'apigility-ui/modal/new-version.html', 'apigility-ui/modal/new-viewmodel.html', 'apigility-ui/modal/view-doctrineparams.html', 'apigility-ui/package/package.html', 'apigility-ui/rest/rest.html', 'apigility-ui/rpc/rpc.html', 'apigility-ui/sidebar/sidebar.html']);
 
 angular.module("apigility-ui/about/about.html", []).run(["$templateCache", function($templateCache) {
   $templateCache.put("apigility-ui/about/about.html",
@@ -108,7 +108,7 @@ angular.module("apigility-ui/api-module/api-module.html", []).run(["$templateCac
     "          <td><a ui-sref=\"ag.rest({api: vm.apiName, ver: vm.version, rest: rest.controller_service_name})\" ng-click=\"vm.setSelected('api'+vm.apiName+'rest'+rest.service_name)\">{{rest.service_name}}</a></td>\n" +
     "          <td>{{rest.route_match}}</td>\n" +
     "          <td>\n" +
-    "            <a href=\"\" ng-if=\"!rest._embedded.documentation.description\" ng-hide=\"vm.disabled\">Add a description for this service</a>\n" +
+    "            <a ng-click=\"vm.addServiceDescriptionModal(rest, 'rest')\" ng-if=\"!rest._embedded.documentation.description\" ng-hide=\"vm.disabled\">Add a description for this service</a>\n" +
     "            <span ng-if=\"rest._embedded.documentation.description\">{{rest._embedded.documentation.description}}</span>\n" +
     "          </td>\n" +
     "        </tr>\n" +
@@ -133,7 +133,7 @@ angular.module("apigility-ui/api-module/api-module.html", []).run(["$templateCac
     "          <td><a ui-sref=\"ag.rpc({api: vm.apiName, ver: vm.version, rpc: rpc.controller_service_name})\" ng-click=\"vm.setSelected('api'+vm.apiName+'rpc'+rpc.service_name)\">{{rpc.service_name}}</a></td>\n" +
     "          <td>{{rpc.route_match}}</td>\n" +
     "          <td>\n" +
-    "            <a href=\"\" ng-if=\"!rpc._embedded.documentation.description\" ng-hide=\"vm.disabled\">Add a description for this service</a>\n" +
+    "            <a ng-click=\"vm.addServiceDescriptionModal(rpc, 'rpc')\" ng-if=\"!rpc._embedded.documentation.description\" ng-hide=\"vm.disabled\">Add a description for this service</a>\n" +
     "            <span ng-if=\"rpc._embedded.documentation.description\">{{rpc._embedded.documentation.description}}</span>\n" +
     "          </td>\n" +
     "        </tr>\n" +
@@ -612,6 +612,28 @@ angular.module("apigility-ui/modal/add-filter.html", []).run(["$templateCache", 
     "<div class=\"modal-footer\">\n" +
     "  <button type=\"button\" class=\"btn btn-default\" ng-click=\"vm.cancel()\">Close</button>\n" +
     "  <button type=\"button\" class=\"btn btn-success btn-sm\" ng-click=\"vm.ok()\" ladda=\"vm.loading\">Save</span></button>\n" +
+    "</div>\n" +
+    "");
+}]);
+
+angular.module("apigility-ui/modal/add-service-description.html", []).run(["$templateCache", function($templateCache) {
+  $templateCache.put("apigility-ui/modal/add-service-description.html",
+    "<div class=\"modal-header\">\n" +
+    "  <h4 class=\"modal-title\">Add service description for <strong>{{vm.service_name}}</strong></h4>\n" +
+    "</div>\n" +
+    "\n" +
+    "<div class=\"modal-body\">\n" +
+    "  <label class=\"control-label\">Description</label>\n" +
+    "  <input class=\"form-control\" type=\"text\" ng-model=\"vm.description\" placeholder=\"Insert the service description\" autofocus />\n" +
+    "</div>\n" +
+    "\n" +
+    "<div class=\"modal-footer\">\n" +
+    "  <div class=\"alert alert-danger\" role=\"alert\" ng-hide=\"!vm.alert\">\n" +
+    "    <span class=\"glyphicon glyphicon-exclamation-sign\" aria-hidden=\"true\"></span> {{vm.alert}}\n" +
+    "  </div>\n" +
+    "\n" +
+    "  <button class=\"btn btn-default\" type=\"button\" ng-click=\"vm.cancel()\">Close</button>\n" +
+    "  <button class=\"btn btn-success\" type=\"button\" ng-click=\"vm.ok()\" ladda=\"vm.loading\">Save</button>\n" +
     "</div>\n" +
     "");
 }]);

--- a/src/index.html
+++ b/src/index.html
@@ -90,6 +90,7 @@
     <script src="apigility-ui/dashboard/dashboard.controller.js"></script>
 
     <script src="apigility-ui/modal/modal.module.js"></script>
+    <script src="apigility-ui/modal/add-service-description.controller.js"></script>
     <script src="apigility-ui/modal/new-api.controller.js"></script>
     <script src="apigility-ui/modal/new-service.controller.js"></script>
     <script src="apigility-ui/modal/new-version.controller.js"></script>


### PR DESCRIPTION
Per #124, the links in the API dashboard to "Add a description for this service" had no handlers attached to them. This patch does so, via the following:

- A new "AddServiceDescription" controller and view in the apigility.modal namespace.
- A new "addServiceDescription" method in the api-module controller that launches the modal, and, on successful completion, reloads the current state.

Fixes #124.