### PR TITLE
Make delete files and directories label clickable

### DIFF
--- a/src/apigility-ui/modal/delete-api.html
+++ b/src/apigility-ui/modal/delete-api.html
@@ -9,7 +9,12 @@
   <p>By default, deleting the API only removes the API module from the application configuration.
   You can re-enable it by re-adding the module to your application configuration at a later date.</p>
 
-  <p><input type="checkbox" ng-model="vm.recursive" ng-disabled="vm.loading"> Delete all files associated with this API?</p>
+  <p>
+    <label>
+      <input type="checkbox" ng-model="vm.recursive" ng-disabled="vm.loading">
+      Delete all files associated with this API?
+    </label>
+  </p>
 </div>
 <div class="modal-footer">
   <button type="button" class="btn btn-default" ng-click="vm.cancel()" ng-disabled="vm.loading">No</button>

--- a/src/apigility-ui/modal/delete-rest.html
+++ b/src/apigility-ui/modal/delete-rest.html
@@ -3,7 +3,12 @@
 </div>
 <div class="modal-body">
   <p class="modal_msg">Are you sure to delete the REST service <strong>{{vm.restName}}</strong>?</p>
-  <p><input type="checkbox" ng-model="vm.recursive" ng-disabled="vm.loading"> Delete all files and directories for this service</p>
+  <p>
+    <label>
+      <input type="checkbox" ng-model="vm.recursive" ng-disabled="vm.loading">
+      Delete all files and directories for this service
+    </label>
+  </p>
 </div>
 <div class="modal-footer">
   <button type="button" class="btn btn-default" ng-click="vm.cancel()">No</button>

--- a/src/apigility-ui/modal/delete-rpc.html
+++ b/src/apigility-ui/modal/delete-rpc.html
@@ -3,7 +3,12 @@
 </div>
 <div class="modal-body">
   <p class="modal_msg">Are you sure to delete the RPC service <strong>{{vm.rpcName}}</strong>?</p>
-  <p><input type="checkbox" ng-model="vm.recursive" ng-disabled="vm.loading"> Delete all files and directories for this service</p>
+  <p>
+    <label>
+      <input type="checkbox" ng-model="vm.recursive" ng-disabled="vm.loading">
+      Delete all files and directories for this service
+    </label>
+  </p>
 </div>
 <div class="modal-footer">
   <button type="button" class="btn btn-default" ng-click="vm.cancel()">No</button>


### PR DESCRIPTION
Hello,

This is a simple PR to make the "Delete all files..." labels in the delete modals clickable. The checkbox is pretty small and the labels are quite large, this makes it easier to select the checkbox.

![selection_001](https://cloud.githubusercontent.com/assets/507871/23281541/95ef4f38-fa15-11e6-8eb9-c3fc959343db.png)

Thanks,
Rob