### PR TITLE
Improve services loading responsiveness (sidebar)

### DIFF
--- a/src/apigility-ui/sidebar/sidebar.html
+++ b/src/apigility-ui/sidebar/sidebar.html
@@ -41,12 +41,16 @@
       <ol class="ng-scope ng-pristine ng-valid angular-ui-tree-nodes" ng-class="{hidden: collapsed}">
         <li class="ng-scope angular-ui-tree-node" ng-repeat="subItem in item.rest track by $index">
           <div class="ng-scope ng-binding angular-ui-tree-handle" ui-tree-handle ng-class="{ 'selected' : 'api'+item.name+'rest'+subItem.service_name === vm.getSelected() }">
-            <span class="glyphicon glyphicon-leaf"></span> <a ui-sref="ag.rest({api: item.name, ver: item.selected_version, rest: subItem.controller_service_name})" ng-click="vm.setSelected('api'+item.name+'rest'+subItem.service_name)">{{subItem.service_name}}</a>
+            <span class="glyphicon glyphicon-leaf"></span>
+            <span ng-if="!subItem.service_name">{{subItem}} <img src="apigility-ui/img/spinning.gif"></span>
+            <a ui-sref="ag.rest({api: item.name, ver: item.selected_version, rest: subItem.controller_service_name})" ng-click="vm.setSelected('api'+item.name+'rest'+subItem.service_name)">{{subItem.service_name}}</a>
           </div>
         </li>
         <li class="ng-scope angular-ui-tree-node" ng-repeat="subItem in item.rpc track by $index">
           <div class="ng-scope ng-binding angular-ui-tree-handle" ui-tree-handle ng-class="{ 'selected' : 'api'+item.name+'rpc'+subItem.service_name === vm.getSelected() }">
-            <span class="glyphicon glyphicon-fire"></span> <a ui-sref="ag.rpc({api: item.name, ver: item.selected_version, rpc: subItem.controller_service_name})" ng-click="vm.setSelected('api'+item.name+'rpc'+subItem.service_name)">{{subItem.service_name}}</a>
+            <span class="glyphicon glyphicon-fire"></span>
+            <span ng-if="!subItem.service_name">{{subItem}} <img src="apigility-ui/img/spinning.gif"></span>
+            <a ui-sref="ag.rpc({api: item.name, ver: item.selected_version, rpc: subItem.controller_service_name})" ng-click="vm.setSelected('api'+item.name+'rpc'+subItem.service_name)">{{subItem.service_name}}</a>
           </div>
         </li>
       </ol>

--- a/src/apigility-ui/templates.js
+++ b/src/apigility-ui/templates.js
@@ -2682,12 +2682,16 @@ angular.module("apigility-ui/sidebar/sidebar.html", []).run(["$templateCache", f
     "      <ol class=\"ng-scope ng-pristine ng-valid angular-ui-tree-nodes\" ng-class=\"{hidden: collapsed}\">\n" +
     "        <li class=\"ng-scope angular-ui-tree-node\" ng-repeat=\"subItem in item.rest track by $index\">\n" +
     "          <div class=\"ng-scope ng-binding angular-ui-tree-handle\" ui-tree-handle ng-class=\"{ 'selected' : 'api'+item.name+'rest'+subItem.service_name === vm.getSelected() }\">\n" +
-    "            <span class=\"glyphicon glyphicon-leaf\"></span> <a ui-sref=\"ag.rest({api: item.name, ver: item.selected_version, rest: subItem.controller_service_name})\" ng-click=\"vm.setSelected('api'+item.name+'rest'+subItem.service_name)\">{{subItem.service_name}}</a>\n" +
+    "            <span class=\"glyphicon glyphicon-leaf\"></span>\n" +
+    "            <span ng-if=\"!subItem.service_name\">{{subItem}} <img src=\"apigility-ui/img/spinning.gif\"></span>\n" +
+    "            <a ui-sref=\"ag.rest({api: item.name, ver: item.selected_version, rest: subItem.controller_service_name})\" ng-click=\"vm.setSelected('api'+item.name+'rest'+subItem.service_name)\">{{subItem.service_name}}</a>\n" +
     "          </div>\n" +
     "        </li>\n" +
     "        <li class=\"ng-scope angular-ui-tree-node\" ng-repeat=\"subItem in item.rpc track by $index\">\n" +
     "          <div class=\"ng-scope ng-binding angular-ui-tree-handle\" ui-tree-handle ng-class=\"{ 'selected' : 'api'+item.name+'rpc'+subItem.service_name === vm.getSelected() }\">\n" +
-    "            <span class=\"glyphicon glyphicon-fire\"></span> <a ui-sref=\"ag.rpc({api: item.name, ver: item.selected_version, rpc: subItem.controller_service_name})\" ng-click=\"vm.setSelected('api'+item.name+'rpc'+subItem.service_name)\">{{subItem.service_name}}</a>\n" +
+    "            <span class=\"glyphicon glyphicon-fire\"></span>\n" +
+    "            <span ng-if=\"!subItem.service_name\">{{subItem}} <img src=\"apigility-ui/img/spinning.gif\"></span>\n" +
+    "            <a ui-sref=\"ag.rpc({api: item.name, ver: item.selected_version, rpc: subItem.controller_service_name})\" ng-click=\"vm.setSelected('api'+item.name+'rpc'+subItem.service_name)\">{{subItem.service_name}}</a>\n" +
     "          </div>\n" +
     "        </li>\n" +
     "      </ol>\n" +


### PR DESCRIPTION
Fixes https://github.com/zfcampus/zf-apigility-admin-ui/issues/152 by adding loaders to the services.

Please note that the order of the services changes after the data is fully loaded. That happens because the data returned by the backend have a different order. The default behavior in the UI is to track the data by using the same order returned by the backend. We could hide this by adding a single loader for all services instead. However, this PR does not intent to change such behavior.

The image below shows the fix:

![apigility_ui_slow_services_fix](https://user-images.githubusercontent.com/5031156/61584612-fd78e900-ab4a-11e9-8968-c4bf1affbdba.gif)
