### PR TITLE
Fix removal of database adapter containing special chars in the name

### DIFF
--- a/src/apigility-ui/service/api.service.js
+++ b/src/apigility-ui/service/api.service.js
@@ -792,7 +792,7 @@
     };
 
     this.deleteDatabase = function(name, callback) {
-      xhr.remove(agApiPath + '/db-adapter/' + name)
+      xhr.remove(agApiPath + '/db-adapter/' + encodeURIComponent(name))
       .then(function (response) {
         growl.success('Database adapter removed');
         return callback(false, response);


### PR DESCRIPTION
Fixes https://github.com/zfcampus/zf-apigility-admin-ui/issues/96.

Database adapters are currently removed by name. When the adapter is created with special characters in the name it cannot be removed. The current fix allows the removal of such databases.